### PR TITLE
Dev/hash

### DIFF
--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -3,3 +3,4 @@ xdoctest >= 0.0.12
 pytest-cov
 coverage >= 4.3.4
 tqdm
+numpy

--- a/ubelt/__init__.py
+++ b/ubelt/__init__.py
@@ -40,6 +40,7 @@ GLOBAL_MODULES = [
     'util_format',
     'util_io',
     'util_list',
+    'util_hash',
     'util_import',
     'util_mixins',
     'util_path',
@@ -77,6 +78,7 @@ if _DOELSE:  # pragma: nobranch
     from ubelt import util_format
     from ubelt import util_io
     from ubelt import util_list
+    from ubelt import util_hash
     from ubelt import util_import
     from ubelt import util_mixins
     from ubelt import util_path
@@ -102,6 +104,7 @@ if _DOELSE:  # pragma: nobranch
     from ubelt.util_io import (readfrom, writeto, touch, delete,)
     from ubelt.util_list import (argsort, boolmask, chunks, compress, flatten,
                                  iterable, take, unique, unique_flags,)
+    from ubelt.util_hash import (hash_data, hash_file,)
     from ubelt.util_import import (split_modpath, modname_to_modpath,
                                    modpath_to_modname, import_module_from_name,
                                    import_module_from_path,)

--- a/ubelt/tests/test_hash.py
+++ b/ubelt/tests/test_hash.py
@@ -1,29 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
 import ubelt as ub
 import numpy as np
 import itertools as it
 
 
-def _benchmark():
-    """
-    On 64-bit processors sha512 may be faster than sha256
-        %timeit hashlib.sha256().update(b'8' * 1000)
-        3.62 µs per loop
-        %timeit hashlib.sha512().update(b'8' * 1000)
-        2.5 µs per loop
+# def _benchmark():
+#     """
+#     On 64-bit processors sha512 may be faster than sha256
+#         %timeit hashlib.sha256().update(b'8' * 1000)
+#         3.62 µs per loop
+#         %timeit hashlib.sha512().update(b'8' * 1000)
+#         2.5 µs per loop
 
-        %timeit hashlib.sha256().update(b'8' * 1)
-        318 ns
-        %timeit hashlib.sha512().update(b'8' * 1)
-        342 ns
+#         %timeit hashlib.sha256().update(b'8' * 1)
+#         318 ns
+#         %timeit hashlib.sha512().update(b'8' * 1)
+#         342 ns
 
-        %timeit hashlib.sha256().update(b'8' * 100000)
-        306 µs
-        %timeit hashlib.sha512().update(b'8' * 100000)
-        213 µs
+#         %timeit hashlib.sha256().update(b'8' * 100000)
+#         306 µs
+#         %timeit hashlib.sha512().update(b'8' * 100000)
+#         213 µs
 
-    References:
-        https://crypto.stackexchange.com/questions/26336/sha512-faster-than-sha256
-    """
+#     References:
+#         https://crypto.stackexchange.com/questions/26336/sha512-faster-than-sha256
+#     """
 
 
 def test_hash_data():

--- a/ubelt/tests/test_hash.py
+++ b/ubelt/tests/test_hash.py
@@ -129,7 +129,10 @@ def test_numpy_float():
     assert hash_sequence(np.float16(3.0)) == hash_sequence(3.0)
     assert hash_sequence(np.float32(3.0)) == hash_sequence(3.0)
     assert hash_sequence(np.float64(3.0)) == hash_sequence(3.0)
-    assert hash_sequence(np.float128(3.0)) == hash_sequence(3.0)
+    try:
+        assert hash_sequence(np.float128(3.0)) == hash_sequence(3.0)
+    except AttributeError:
+        pass
 
 
 def test_numpy_random_state():

--- a/ubelt/tests/test_hash.py
+++ b/ubelt/tests/test_hash.py
@@ -1,0 +1,179 @@
+import ubelt as ub
+import numpy as np
+
+
+def _benchmark():
+    """
+    On 64-bit processors sha512 may be faster than sha256
+        %timeit hashlib.sha256().update(b'8' * 1000)
+        3.62 µs per loop
+        %timeit hashlib.sha512().update(b'8' * 1000)
+        2.5 µs per loop
+
+        %timeit hashlib.sha256().update(b'8' * 1)
+        318 ns
+        %timeit hashlib.sha512().update(b'8' * 1)
+        342 ns
+
+        %timeit hashlib.sha256().update(b'8' * 100000)
+        306 µs
+        %timeit hashlib.sha512().update(b'8' * 100000)
+        213 µs
+
+    References:
+        https://crypto.stackexchange.com/questions/26336/sha512-faster-than-sha256
+    """
+
+
+def test_hash_data():
+    counter = [0]
+    failed = []
+    def check_hash(input_, want=None):
+        count = counter[0] = counter[0] + 1
+        got = ub.hash_data(input_)
+        # assert got.startswith(want), 'want={}, got={}'.format(want, got)
+        if want is not None and not got.startswith(want):
+            item = (got, input_, count, want)
+            failed.append(item)
+            print(item)
+
+    check_hash('1', 'kjckshvqyxgutulxpqdcbgwqynecikho')
+    check_hash(['1'], 'vbppcawudziqinqcuojszzvdayryhhmb')
+    check_hash(tuple(['1']), 'vbppcawudziqinqcuojszzvdayryhhmb')
+    check_hash(b'12', 'zklkttlbjthzkppeeermruktfmhsefhl')
+    check_hash([b'1', b'2'], 'bggphxtjkmeoeoxonlsrfoehmvusfxqu')
+    check_hash(['1', '2', '3'], 'rpaokzkayydloniwutxhdqmhsibezowc')
+    check_hash(['1', np.array([1, 2, 3]), '3'], 'jihkzpzqgwahderjiblyaklxycdldzpg')
+    check_hash('123', 'aheslytcdblfeuxjkurjltxzgsdqkvel')
+    check_hash(zip([1, 2, 3], [4, 5, 6]), 'xdfqqqjzzdwitclyighsbhuspgeutuod')
+    print(ub.repr2(failed, nl=1))
+    assert len(failed) == 0
+
+
+def test_numpy_object_array():
+    """
+    _HASHABLE_EXTENSIONS = ub.util_hash._HASHABLE_EXTENSIONS
+    """
+    # An object array should have the same repr as a list of a tuple of data
+    data = np.array([1, 2, 3], dtype=object)
+    objhash = ub.hash_data(data)
+    assert ub.hash_data([1, 2, 3]) == objhash
+    assert ub.hash_data((1, 2, 3)) == objhash
+
+    # Ensure this works when the object array is nested
+    data = [np.array([1, 2, 3], dtype=object)]
+    objhash = ub.hash_data(data)
+    assert ub.hash_data([[1, 2, 3]]) == objhash
+    assert ub.hash_data([(1, 2, 3)]) == objhash
+    assert ub.hash_data(([1, 2, 3],)) == objhash
+
+
+class HashTracer(object):
+    """ class which extracts the sequence that would be hashed """
+    def __init__(self):
+        self.sequence = []
+
+    def hexdigest(self):
+        return b'00000000'
+
+    def __call__(self):
+        return self
+
+    def update(self, data):
+        self.sequence.append(data)
+
+
+def test_ndarray_int_object_convert():
+    data_list = [[1, 2, 3], [4, 5, 6]]
+
+    data = np.array(data_list, dtype=np.int64)
+
+    s1 = b''.join(hash_sequence(data.astype(object)))
+    s2 = b''.join(hash_sequence(data_list))
+    s3 = b''.join(hash_sequence(data.tolist()))
+    s4 = b''.join(hash_sequence(data.astype(np.uint8).astype(object)))
+
+    assert s1 == s4
+    assert s2 == s4
+    assert s3 == s4
+
+    hashid = ub.hash_data(data)
+    assert hashid == ub.hash_data(data.ravel()), (
+        'currently we expect ravel not to matter')
+    assert hashid != ub.hash_data(data.astype(np.float32))
+    assert hashid != ub.hash_data(data.astype(np.int32))
+    assert hashid != ub.hash_data(data.astype(np.int8))
+
+
+def hash_sequence(data):
+    tracer = HashTracer()
+    ub.hash_data(data, hasher=tracer)
+    return tracer.sequence
+
+
+def test_numpy_int():
+    assert hash_sequence(np.int8(3)) == hash_sequence(3)
+    assert hash_sequence(np.int16(3)) == hash_sequence(3)
+    assert hash_sequence(np.int32(3)) == hash_sequence(3)
+    assert hash_sequence(np.int64(3)) == hash_sequence(3)
+    assert hash_sequence(np.uint8(3)) == hash_sequence(3)
+    assert hash_sequence(np.uint16(3)) == hash_sequence(3)
+    assert hash_sequence(np.uint32(3)) == hash_sequence(3)
+    assert hash_sequence(np.uint64(3)) == hash_sequence(3)
+
+
+def test_numpy_float():
+    assert hash_sequence(np.float16(3.0)) == hash_sequence(3.0)
+    assert hash_sequence(np.float32(3.0)) == hash_sequence(3.0)
+    assert hash_sequence(np.float64(3.0)) == hash_sequence(3.0)
+    assert hash_sequence(np.float128(3.0)) == hash_sequence(3.0)
+
+
+def test_numpy_random_state():
+    data = np.random.RandomState(0)
+    assert ub.hash_data(data) == 'pooeuqejltfttjdzsgwzlbffznqctsnq'
+    # hash_sequence(data)
+
+
+def test_uuid():
+    import uuid
+    data = uuid.UUID('12345678-1234-1234-1234-123456789abc')
+    assert hash_sequence(data) == [b'UUID\x124Vx\x124\x124\x124\x124Vx\x9a\xbc']
+    assert ub.hash_data(data) == 'tuvnocpbbdgcvnaexwxtqugntcdznjbh'
+    assert ub.hash_data(data.bytes) != ub.hash_data(data), (
+        'the fact that it is a UUID should reflect in the hash')
+
+
+def test_hash_data_custom_alphabet():
+    data = 1
+    hashid_26 = ub.hash_data(data, alphabet=None)
+    assert hashid_26 == 'cmhclfgczcydmexhcztydbueglwquqap'
+    hashid_16 = ub.hash_data(data, alphabet='hex')
+    assert hashid_16 == '8bf2a1f4dbea6e59e5c2ec4077498c44'
+    hashid_2 = ub.hash_data(data, alphabet=['0', '1'])
+    assert hashid_2 == '01101010010100000001100001101010'
+
+
+def test_hash_file():
+    from os.path import join
+    fpath = join(ub.ensure_app_cache_dir('ubelt'), 'tmp.txt')
+    ub.writeto(fpath, 'foobar')
+    hashid1_a = ub.hash_file(fpath, hasher='sha512', hashlen=8, stride=1, blocksize=1)
+    hashid2_a = ub.hash_file(fpath, hasher='sha512', hashlen=8, stride=2, blocksize=1)
+
+    hashid1_b = ub.hash_file(fpath, hasher='sha512', hashlen=8, stride=1, blocksize=10)
+    hashid2_b = ub.hash_file(fpath, hasher='sha512', hashlen=8, stride=2, blocksize=10)
+
+    assert hashid1_a == hashid1_b
+    assert hashid2_a != hashid2_b, 'blocksize matters when stride is > 1'
+    assert hashid1_a != hashid2_a
+
+
+if __name__ == '__main__':
+    r"""
+    CommandLine:
+        python ~/code/ubelt/ubelt/tests/test_hash.py
+        pytest ~/code/ubelt/ubelt/tests/test_hash.py
+    """
+    import xdoctest
+    xdoctest.doctest_module(__file__)

--- a/ubelt/tests/test_hash.py
+++ b/ubelt/tests/test_hash.py
@@ -10,6 +10,7 @@ from ubelt.util_hash import _hashable_sequence
 from ubelt.util_hash import _rectify_hasher
 hash_sequence = _hashable_sequence
 
+
 def _benchmark():
     """
     On 64-bit processors sha512 may be faster than sha256

--- a/ubelt/tests/test_hash.py
+++ b/ubelt/tests/test_hash.py
@@ -46,7 +46,7 @@ def test_hash_data():
     check_hash(b'12', 'ftzqivzayzivmobwymodjnnzzxzrvvjz')
     check_hash([b'1', b'2'], 'qzxwryuzknxbtlkzpsrkhwijqhiiqrkd')
     check_hash(['1', '2', '3'], 'rdycrmgwpmgpsmfxyzrwkeahirtudoxl')
-    check_hash(['1', np.array([1, 2, 3]), '3'], 'hebvtnbqjsdusmeqqqvadipihgmqgsos')
+    check_hash(['1', np.array([1, 2, 3], dtype=np.int64), '3'], 'hebvtnbqjsdusmeqqqvadipihgmqgsos')
     check_hash('123', 'lxssoxdkstvccsyqaybaokehclyctgmn')
     check_hash(zip([1, 2, 3], [4, 5, 6]), 'rsizgermosnbnswfohzlfhvhzdoojzob')
     print(ub.repr2(failed, nl=1))

--- a/ubelt/tests/test_platform.py
+++ b/ubelt/tests/test_platform.py
@@ -39,9 +39,13 @@ def test_cmd_tee_auto():
     assert result['out'] == '\n'.join(list(map(str, range(100)))) + '\n'
 
 
+# @pytest.mark.skip
+@pytest.mark.timeout(5)
 def test_cmd_tee_thread():
     """
     pytest ubelt/tests/test_platform.py::test_cmd_tee_thread
+
+    FIXME: this test hangs on calculex for some reason
     """
     import threading
     # check which threads currently exist (ideally 1)
@@ -133,5 +137,9 @@ def test_cmd_interleaved_streams_py():
 
 
 if __name__ == '__main__':
+    """
+        pytest ubelt/tests/test_platform.py
+    """
+
     import xdoctest
     xdoctest.doctest_module(__file__)

--- a/ubelt/util_hash.py
+++ b/ubelt/util_hash.py
@@ -6,17 +6,7 @@ The hashes should be determenistic across platforms.
 
 NOTE:
     The exact hashes generated for data object and files may change in the
-    future and should not be relied on between versions. Eventually we plan to
-    change this policy and gaurentee a stable hashing scheme across future
-    versions.
-
-TODO: Before we merge this... should we:
-    How is the custom hashing scheme different or better than simply using
-    pickle. Perhaps its not, and it should be using pickle.
-        * Reason1: compatibility between python 2 and 3. We dont differentiate
-        between bytes and unicode, whereas pickle would.
-        * Reason2: safety: this will complain about unordered things such as
-            dicts.
+    future. When this happens the `HASH_VERSION` attribute will be incremented.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 import hashlib
@@ -141,6 +131,8 @@ def _rectify_base(base):
         >>> assert _rectify_base('abc') is _ALPHABET_26
         >>> assert _rectify_base(10) is _ALPHABET_10
         >>> assert _rectify_base(['1', '2']) == ['1', '2']
+        >>> import pytest
+        >>> assert pytest.raises(TypeError, _rectify_base, 'uselist')
     """
     if base is NoParam or base == 'default':
         return DEFAULT_ALPHABET

--- a/ubelt/util_hash.py
+++ b/ubelt/util_hash.py
@@ -2,7 +2,7 @@
 """
 Wrappers around hashlib functions to generate hash signatures for common data.
 
-The hashes should be the same across platforms for the same data.
+The hashes should be determenistic across platforms.
 
 NOTE:
     The exact hashes generated for data object and files may change in the

--- a/ubelt/util_hash.py
+++ b/ubelt/util_hash.py
@@ -517,16 +517,27 @@ def _convert_hexstr_base(hexstr, alphabet):
     return newbase_str
 
 
+def _digest_hasher(hasher, hashlen, alphabet):
+    """ counterpart to _update_hasher """
+    # Get a 128 character hex string
+    hex_text = hasher.hexdigest()
+    # Shorten length of string (by increasing base)
+    base_text = _convert_hexstr_base(hex_text, alphabet)
+    # Truncate
+    text = base_text[:hashlen]
+    return text
+
+
 def hash_data(data, hasher=NoParam, hashlen=NoParam, alphabet=NoParam):
     r"""
     Get a unique hash depending on the state of the data.
 
     Args:
         data (object): any sort of loosely organized data
-        hashlen (None): maximum number of symbols in the returned hash.
+        hashlen (int): maximum number of symbols in the returned hash. If
+            not specified, all are returned.
         alphabet (list): alphabet of symbols. If not specified uses base 26.
-        hasher (HASH): hash algorithm from hashlib, if None uses
-            `DEFAULT_HASHER`.
+        hasher (HASH): hash algorithm from hashlib, defaults to `sha512`.
 
     Returns:
         str: text -  hash string
@@ -540,12 +551,8 @@ def hash_data(data, hasher=NoParam, hashlen=NoParam, alphabet=NoParam):
     hasher = _rectify_hasher(hasher)()
     # Feed the data into the hasher
     _update_hasher(hasher, data)
-    # Get a 128 character hex string
-    hex_text = hasher.hexdigest()
-    # Shorten length of string (by increasing base)
-    base_text = _convert_hexstr_base(hex_text, alphabet)
-    # Truncate
-    text = base_text[:hashlen]
+    # Get the hashed representation
+    text = _digest_hasher(hasher, hashlen, alphabet)
     return text
 
 
@@ -595,9 +602,9 @@ def hash_file(fpath, blocksize=65536, stride=1, hasher=NoParam,
             while len(buf) > 0:
                 hasher.update(buf)
                 buf = file.read(blocksize)
-        hexid = hasher.hexdigest()
-        hashid = _convert_hexstr_base(hexid, alphabet)[:hashlen]
-        return hashid
+    # Get the hashed representation
+    text = _digest_hasher(hasher, hashlen, alphabet)
+    return text
 
 if __name__ == '__main__':
     r"""

--- a/ubelt/util_hash.py
+++ b/ubelt/util_hash.py
@@ -7,6 +7,10 @@ NOTE:
     future and should not be relied on between versions. Eventually we plan to
     change this policy and gaurentee a stable hashing scheme across future
     versions.
+
+TODO: Before we merge this... should we:
+    [ ] Change default base to 16?
+    [ ] Remove hashlen?
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 import hashlib
@@ -17,6 +21,8 @@ from six.moves import zip
 __all__ = ['hash_data', 'hash_file']
 
 HASH_VERSION = 1  # incremented when we make a change that modifies hashes
+
+_ALPHABET_16 = list('0123456789abcdef')
 
 _ALPHABET_26 = [
     'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o',
@@ -367,11 +373,13 @@ def _convert_hexstr_base(hexstr, alphabet):
 
     Example:
         >>> print(_convert_hexstr_base('ffffffff', _ALPHABET_26))
-        vxlrmxn
+        nxmrlxv
         >>> print(_convert_hexstr_base('0', _ALPHABET_26))
         0
         >>> print(_convert_hexstr_base('-ffffffff', _ALPHABET_26))
-        -vxlrmxn
+        -nxmrlxv
+        >>> print(_convert_hexstr_base('aafffff1', _ALPHABET_16))
+        aafffff1
 
     Sympy:
         >>> import sympy as sy
@@ -405,9 +413,8 @@ def _convert_hexstr_base(hexstr, alphabet):
         digits.append(alphabet[x % bigbase])
         x //= bigbase
     if sign < 0:
-        digits.reverse()
         digits.append('-')
-        digits.reverse()
+    digits.reverse()
     newbase_str = ''.join(digits)
     return newbase_str
 
@@ -428,7 +435,7 @@ def hash_data(data, hasher=None, hashlen=None, alphabet=None):
 
     Example:
         >>> print(hash_data([1, 2, (3, '4')], hashlen=8, hasher='sha512'))
-        vctyzxid
+        hpddmqdi
     """
     alphabet = _rectify_alphabet(alphabet)
     hashlen = _rectify_hashlen(hashlen)
@@ -475,7 +482,7 @@ def hash_file(fpath, blocksize=65536, stride=1, hasher=None, hashlen=None,
         >>> fpath = join(ub.ensure_app_cache_dir('ubelt'), 'tmp.txt')
         >>> ub.writeto(fpath, 'foobar')
         >>> print(ub.hash_file(fpath, hasher='sha512', hashlen=8))
-        ruvvlhnz
+        vkiodmcj
     """
     alphabet = _rectify_alphabet(alphabet)
     hashlen = _rectify_hashlen(hashlen)

--- a/ubelt/util_hash.py
+++ b/ubelt/util_hash.py
@@ -1,0 +1,506 @@
+# -*- coding: utf-8 -*-
+"""
+Wrappers around hashlib functions to generate hash signatures for common data.
+
+NOTE:
+    The exact hashes generated for data object and files may change in the
+    future and should not be relied on between versions. Eventually we plan to
+    change this policy and gaurentee a stable hashing scheme across future
+    versions.
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+import hashlib
+import six
+import uuid
+from six.moves import zip
+
+__all__ = ['hash_data', 'hash_file']
+
+HASH_VERSION = 1  # incremented when we make a change that modifies hashes
+
+_ALPHABET_26 = [
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o',
+    'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z']
+
+
+_HASH_LEN = 32
+
+if six.PY2:
+    _stringlike = (basestring, bytes)  # NOQA
+else:
+    _stringlike = (str, bytes)  # NOQA
+
+
+# Default to 512 because it is often faster than 256 on 64bit systems:
+# Reference: https://crypto.stackexchange.com/questions/26336/faster
+DEFAULT_HASHER = hashlib.sha512
+
+
+if six.PY2:
+    import codecs
+    def _py2_to_bytes(int_, length, byteorder='big'):
+        h = '%x' % int_
+        s = ('0' * (len(h) % 2) + h).zfill(length * 2).decode('hex')
+        bytes_ =  s if byteorder == 'big' else s[::-1]
+        return bytes_
+
+    def _int_to_bytes(int_):
+        length = max(4, int_.bit_length())
+        bytes_ = _py2_to_bytes(int_, length, 'big')
+        return bytes_
+
+    def _bytes_to_int(bytes_):
+        int_ = int(codecs.encode(bytes_, 'hex'), 16)
+        return int_
+else:
+    def _int_to_bytes(int_):
+        r"""
+        Converts an integer into its byte representation
+        assumes int32 by default, but dynamically handles larger ints
+
+        Example:
+            >>> int_ = 1
+            >>> assert _bytes_to_int((_int_to_bytes(int_))) == int_
+            >>> assert _int_to_bytes(int_) == b'\x00\x00\x00\x01'
+        """
+        length = max(4, int_.bit_length())
+        bytes_ = int_.to_bytes(length, byteorder='big')
+        return bytes_
+
+    def _bytes_to_int(bytes_):
+        r"""
+        Converts a string of bytes into its integer representation (big-endian)
+
+        Example:
+            >>> bytes_ = b'\x00\x00\x00\x01'
+            >>> assert _int_to_bytes((_bytes_to_int(bytes_))) == bytes_
+            >>> assert _bytes_to_int(bytes_) == 1
+        """
+        int_ = int.from_bytes(bytes_, 'big')
+        return int_
+
+
+def _rectify_hasher(hasher):
+    """
+    Convert a string-based key into a hasher class
+
+    Example:
+        >>> assert _rectify_hasher(None) is DEFAULT_HASHER
+        >>> assert _rectify_hasher('sha1') is hashlib.sha1
+        >>> assert _rectify_hasher('sha256') is hashlib.sha256
+        >>> assert _rectify_hasher('sha512') is hashlib.sha512
+        >>> assert _rectify_hasher('md5') is hashlib.md5
+        >>> assert _rectify_hasher(hashlib.sha1) is hashlib.sha1
+        >>> #assert _rectify_hasher(hashlib.sha1())
+        >>> import pytest
+        >>> assert pytest.raises(KeyError, _rectify_hasher, '42')
+        >>> #assert pytest.raises(TypeError, _rectify_hasher, object)
+    """
+    if hasher is None:
+        hasher = DEFAULT_HASHER
+    elif isinstance(hasher, six.string_types):
+        if hasher not in hashlib.algorithms_available:
+            raise KeyError('unknown hasher: {}'.format(hasher))
+        else:
+            hasher = getattr(hashlib, hasher)
+    return hasher
+
+
+def _rectify_alphabet(alphabet):
+    """
+    Example:
+        >>> assert _rectify_alphabet(None) is _ALPHABET_26
+        >>> assert _rectify_alphabet(['1', '2']) == ['1', '2']
+    """
+    if alphabet is None:
+        return _ALPHABET_26
+    else:
+        return alphabet
+
+
+def _rectify_hashlen(hashlen):
+    """
+    Example:
+        >>> assert _rectify_hashlen(None) is _HASH_LEN
+        >>> assert _rectify_hashlen(8) == 8
+    """
+    if hashlen is None:
+        return _HASH_LEN
+    else:
+        return hashlen
+
+
+class HashableExtensions():
+    """
+    Singleton helper class for managing non-builtin (e.g. numpy) hash types
+    """
+    def __init__(self):
+        self.keyed_extensions = {}
+        self.iterable_checks = []
+
+    def register(self, hash_types):
+        # ensure iterable
+        if not isinstance(hash_types, (list, tuple)):
+            hash_types = [hash_types]
+        def _wrap(hash_func):
+            for hash_type in hash_types:
+                key = (hash_type.__module__, hash_type.__name__)
+                self.keyed_extensions[key] = (hash_type, hash_func)
+                # self.extensions.append((hash_type, hash_func))
+            return hash_func
+        return _wrap
+
+    def add_iterable_check(self, func):
+        """
+        Registers a function that detects when a type is iterable
+        """
+        self.iterable_checks.append(func)
+        return func
+
+    def lookup(self, data):
+        """
+        Returns an appropriate function to hash `data` if one has been
+        registered.
+
+        Raises:
+            TypeError : if data has no registered hash methods
+
+        Example:
+            >>> self = HashableExtensions()
+            >>> self._register_numpy_extensions()
+            >>> self._register_builtin_class_extensions()
+
+            >>> data = np.array([1, 2, 3])
+            >>> self.lookup(data[0])
+
+            >>> class Foo(object):
+            >>>     def __init__(f):
+            >>>         f.attr = 1
+            >>> data = Foo()
+            >>> import pytest
+            >>> assert pytest.raises(TypeError, self.lookup, data)
+
+            >>> data = uuid.uuid4()
+            >>> self.lookup(data)
+        """
+        # Maybe try using functools.singledispatch instead?
+        # First try fast O(1) lookup
+        query_hash_type = data.__class__
+        key = (query_hash_type.__module__, query_hash_type.__name__)
+        try:
+            hash_type, hash_func = self.keyed_extensions[key]
+        except KeyError:
+            raise TypeError('No registered hash func for hashable type=%r' % (
+                    query_hash_type))
+        return hash_func
+
+    def _register_numpy_extensions(self):
+        """
+        Numpy extensions are builtin
+        """
+        @self.add_iterable_check
+        def is_object_ndarray(data):
+            # ndarrays of objects cannot be hashed directly.
+            return isinstance(data, np.ndarray) and data.dtype.kind == 'O'
+
+        @self.register(np.ndarray)
+        def hash_numpy_array(data):
+            if data.dtype.kind == 'O':
+                msg = 'directly hashing ndarrays with dtype=object is unstable'
+                raise TypeError(msg)
+                # warnings.warn(msg, RuntimeWarning)
+                # hashable = data.dumps()
+            else:
+                # NOTE: tobytes() views the array in 1D (via ravel())
+                # this means the shape is not encoded in the hash
+                hashable = data.tobytes()
+            prefix = b'NDARR'
+            return prefix, hashable
+
+        @self.register((np.int64, np.int32, np.int16, np.int8) +
+                       (np.uint64, np.uint32, np.uint16, np.uint8))
+        def _hash_numpy_int(data):
+            return _convert_to_hashable(int(data))
+
+        @self.register((np.float128, np.float64, np.float32, np.float16))
+        def _hash_numpy_float(data):
+            return _convert_to_hashable(float(data))
+
+        @self.register(np.random.RandomState)
+        def _hash_numpy_random_state(data):
+            ver, ints, pos, has_gauss, cached = data.get_state()
+            hashable = (_convert_to_hashable(ver)[1] +
+                        _convert_to_hashable(ints)[1] +
+                        _convert_to_hashable(pos)[1] +
+                        _convert_to_hashable(has_gauss)[1] +
+                        _convert_to_hashable(cached)[1])
+            prefix = b'RNG'
+            return prefix, hashable
+
+    def _register_builtin_class_extensions(self):
+        """
+        Register hashing extensions for a selection of classes included in
+        python stdlib.
+        """
+        @self.register(uuid.UUID)
+        def _hash_uuid(data):
+            hashable = data.bytes
+            prefix = b'UUID'
+            return prefix, hashable
+
+_HASHABLE_EXTENSIONS = HashableExtensions()
+
+
+try:
+    import numpy as np
+    _HASHABLE_EXTENSIONS._register_numpy_extensions()
+except ImportError:  # nocover
+    pass
+
+_HASHABLE_EXTENSIONS._register_builtin_class_extensions()
+
+
+def _convert_to_hashable(data):
+    r"""
+    Converts `data` into a hashable byte representation if an appropriate
+    hashing function is known.
+
+    Args:
+        data (object): arbitrary data
+
+    Returns:
+        tuple(bytes, bytes): prefix, hashable:
+            a prefix hinting the original data type and the byte representation
+            of `data`.
+
+    Raises:
+        TypeError : if data has no registered hash methods
+
+    Example:
+        >>> assert _convert_to_hashable(None) == (b'NONE', b'')
+        >>> assert _convert_to_hashable('string') == (b'TXT', b'string')
+        >>> assert _convert_to_hashable(1) == (b'INT', b'\x00\x00\x00\x01')
+        >>> assert _convert_to_hashable(1.0) == (b'FLT', b'\x00\x00\x00\x01/\x00\x00\x00\x01')
+    """
+    # HANDLE MOST COMMON TYPES FIRST
+    if data is None:
+        hashable = b''
+        prefix = b'NONE'
+    elif isinstance(data, six.binary_type):
+        hashable = data
+        prefix = b'TXT'
+    elif isinstance(data, six.text_type):
+        # convert unicode into bytes
+        hashable = data.encode('utf-8')
+        prefix = b'TXT'
+    elif isinstance(data, int):
+        # warnings.warn('Hashing ints is slow, numpy is prefered')
+        hashable = _int_to_bytes(data)
+        # hashable = data.to_bytes(8, byteorder='big')
+        prefix = b'INT'
+    elif isinstance(data, float):
+        a, b = float(data).as_integer_ratio()
+        hashable = _int_to_bytes(a) + b'/' +  _int_to_bytes(b)
+        prefix = b'FLT'
+        # hashable = repr(data).encode('utf8')
+        # prefix = b'FLT'
+    else:
+        # Then dynamically look up any other type
+        hash_func = _HASHABLE_EXTENSIONS.lookup(data)
+        prefix, hashable = hash_func(data)
+    return prefix, hashable
+
+
+def _update_hasher(hasher, data):
+    """
+    Converts `data` into a byte representation and calls update on the hasher
+    `hashlib.HASH` algorithm.
+
+    Example:
+        >>> hasher = hashlib.sha512()
+        >>> data = [1, 2, ['a', 2, 'c']]
+        >>> _update_hasher(hasher, data)
+        >>> print(hasher.hexdigest()[0:8])
+        e31406aa
+    """
+    # Determine if the data should be hashed directly or iterated through
+    if isinstance(data, (tuple, list, zip)):
+        needs_iteration = True
+    else:
+        needs_iteration = any(check(data) for check in
+                              _HASHABLE_EXTENSIONS.iterable_checks)
+
+    if needs_iteration:
+        # Denote that we are hashing over an iterable
+        SEP = b'SEP'
+        iter_prefix = b'ITER'
+        iter_ = iter(data)
+        hasher.update(iter_prefix)
+        # first, try to nest quickly without recursive calls
+        # (this works if all data in the sequence is a non-iterable)
+        try:
+            for item in iter_:
+                prefix, hashable = _convert_to_hashable(item)
+                binary_data = SEP + prefix + hashable
+                hasher.update(binary_data)
+        except TypeError:
+            # need to use recursive calls
+            # Update based on current item
+            _update_hasher(hasher, item)
+            for item in iter_:
+                # Ensure the items have a spacer between them
+                hasher.update(SEP)
+                _update_hasher(hasher, item)
+    else:
+        prefix, hashable = _convert_to_hashable(data)
+        binary_data = prefix + hashable
+        hasher.update(binary_data)
+
+
+def _convert_hexstr_base(hexstr, alphabet):
+    r"""
+    Packs a long hexstr into a shorter length string with a larger base.
+
+    Args:
+        hexstr (str): string of hexidecimal symbols to convert
+        alphabet (list): symbols of the conversion base
+
+    Example:
+        >>> print(_convert_hexstr_base('ffffffff', _ALPHABET_26))
+        vxlrmxn
+        >>> print(_convert_hexstr_base('0', _ALPHABET_26))
+        0
+        >>> print(_convert_hexstr_base('-ffffffff', _ALPHABET_26))
+        -vxlrmxn
+
+    Sympy:
+        >>> import sympy as sy
+        >>> # Determine the length savings with lossless conversion
+        >>> consts = dict(hexbase=16, hexlen=256, bigbase=27)
+        >>> symbols = sy.symbols('hexbase, hexlen, bigbase, newlen')
+        >>> haexbase, hexlen, bigbase, newlen = symbols
+        >>> eqn = sy.Eq(16 ** hexlen,  bigbase ** newlen)
+        >>> newlen_ans = sy.solve(eqn, newlen)[0].subs(consts).evalf()
+        >>> print('newlen_ans = %r' % (newlen_ans,))
+        >>> # for a 27 char alphabet we can get 216
+        >>> print('Required length for lossless conversion len2 = %r' % (len2,))
+        >>> def info(base, len):
+        ...     bits = base ** len
+        ...     print('base = %r' % (base,))
+        ...     print('len = %r' % (len,))
+        ...     print('bits = %r' % (bits,))
+        >>> info(16, 256)
+        >>> info(27, 16)
+        >>> info(27, 64)
+        >>> info(27, 216)
+    """
+    bigbase = len(alphabet)
+    x = int(hexstr, 16)  # first convert to base 16
+    if x == 0:
+        return '0'
+    sign = 1 if x > 0 else -1
+    x *= sign
+    digits = []
+    while x:
+        digits.append(alphabet[x % bigbase])
+        x //= bigbase
+    if sign < 0:
+        digits.reverse()
+        digits.append('-')
+        digits.reverse()
+    newbase_str = ''.join(digits)
+    return newbase_str
+
+
+def hash_data(data, hasher=None, hashlen=None, alphabet=None):
+    r"""
+    Get a unique hash depending on the state of the data.
+
+    Args:
+        data (object): any sort of loosely organized data
+        hashlen (None): maximum number of symbols in the returned hash.
+        alphabet (list): alphabet of symbols. If not specified uses base 26.
+        hasher (HASH): hash algorithm from hashlib, if None uses
+            `DEFAULT_HASHER`.
+
+    Returns:
+        str: text -  hash string
+
+    Example:
+        >>> print(hash_data([1, 2, (3, '4')], hashlen=8, hasher='sha512'))
+        vctyzxid
+    """
+    alphabet = _rectify_alphabet(alphabet)
+    hashlen = _rectify_hashlen(hashlen)
+    hasher = _rectify_hasher(hasher)()
+    # Feed the data into the hasher
+    _update_hasher(hasher, data)
+    # Get a 128 character hex string
+    hex_text = hasher.hexdigest()
+    if alphabet == 'hex':
+        base_text = hex_text
+    else:
+        # Shorten length of string (by increasing base)
+        base_text = _convert_hexstr_base(hex_text, alphabet)
+    # Truncate
+    text = base_text[:hashlen]
+    return text
+
+
+def hash_file(fpath, blocksize=65536, stride=1, hasher=None, hashlen=None,
+              alphabet=None):
+    r"""
+    Hashes the data in a file on disk.
+
+    Args:
+        fpath (str):  file path string
+        blocksize (int): 2 ** 16. Affects speed of reading file
+        hasher (None):  defaults to sha1 for fast (but non-robust) hashing
+        stride (int): strides > 1 skip data to hash, useful for faster
+                      hashing, but less accurate, also makes hash dependant on
+                      blocksize.
+
+    Notes:
+        For better hashes keep stride = 1
+        For faster hashes set stride > 1
+        blocksize matters when stride > 1
+
+    References:
+        http://stackoverflow.com/questions/3431825/md5-checksum-of-a-file
+        http://stackoverflow.com/questions/5001893/when-to-use-sha-1-vs-sha-2
+
+    Example:
+        >>> import ubelt as ub
+        >>> from os.path import join
+        >>> fpath = join(ub.ensure_app_cache_dir('ubelt'), 'tmp.txt')
+        >>> ub.writeto(fpath, 'foobar')
+        >>> print(ub.hash_file(fpath, hasher='sha512', hashlen=8))
+        ruvvlhnz
+    """
+    alphabet = _rectify_alphabet(alphabet)
+    hashlen = _rectify_hashlen(hashlen)
+    hasher = _rectify_hasher(hasher)()
+    with open(fpath, 'rb') as file:
+        buf = file.read(blocksize)
+        if stride > 1:
+            # skip blocks when stride is greater than 1
+            while len(buf) > 0:
+                hasher.update(buf)
+                file.seek(blocksize * (stride - 1), 1)
+                buf = file.read(blocksize)
+        else:
+            # otherwise hash the entire file
+            while len(buf) > 0:
+                hasher.update(buf)
+                buf = file.read(blocksize)
+        hexid = hasher.hexdigest()
+        hashid = _convert_hexstr_base(hexid, alphabet)[:hashlen]
+        return hashid
+
+if __name__ == '__main__':
+    r"""
+    CommandLine:
+        python -m ubelt.util_hash all
+    """
+    import xdoctest
+    xdoctest.doctest_module(__file__)

--- a/ubelt/util_hash.py
+++ b/ubelt/util_hash.py
@@ -2,6 +2,8 @@
 """
 Wrappers around hashlib functions to generate hash signatures for common data.
 
+The hashes should be the same across platforms for the same data.
+
 NOTE:
     The exact hashes generated for data object and files may change in the
     future and should not be relied on between versions. Eventually we plan to
@@ -228,7 +230,11 @@ class HashableExtensions():
         def _hash_numpy_int(data):
             return _convert_to_hashable(int(data))
 
-        @self.register((np.float128, np.float64, np.float32, np.float16))
+        numpy_floating_types = (np.float16, np.float32, np.float64)
+        if hasattr(np, 'float128'):  # nocover
+            numpy_floating_types = numpy_floating_types + (np.float128,)
+
+        @self.register(numpy_floating_types)
         def _hash_numpy_float(data):
             return _convert_to_hashable(float(data))
 

--- a/ubelt/util_import.py
+++ b/ubelt/util_import.py
@@ -145,7 +145,7 @@ def import_module_from_name(modname):
         >>> # test with modules that wont be imported in normal circumstances
         >>> # todo write a test where we gaurentee this
         >>> modname_list = [
-        >>>     'test',
+        >>>     #'test',
         >>>     'pickletools',
         >>>     'lib2to3.fixes.fix_apply',
         >>> ]

--- a/whatsnew.txt
+++ b/whatsnew.txt
@@ -5,6 +5,9 @@ ADD: new arg `total` to ub.chunks lets you specify how long an iterable is if
 
 ENH: `ub.Timerit` reports better measures of expected time.
 
+ADD: `ub.hash_data` and `ub.hash_file` for easy hashing of arbitrary structured
+    data and file.
+
 
 version: 0.0.37
 ---------------


### PR DESCRIPTION
Adds hashing functions for common ordered data structures

TODO: Before we merge this... should we:
    [x] Change default base to 16? No, I like base 26 better for ubelt. Added option for base 10 and 16.
    [x] Remove hashlen default? (set to None by default)
    [x] Choose default hasher? (sha512)
    [x] Make the rectify functions more robust?
    [x] Should numpy hashes encode the shape (probably)?
    [x] change variable name alphabet to symbols? (still not sure, maybe base?) base works
  
  