### PR TITLE
Rework util import errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Version 0.8.1] - Unreleased
 
+### Added
+* Added `dpath` as an argument to `ub.augpath`
+
 ### Fixed
 * Custom extensions for `ub.hash_data` are fixed. Previously they were not passed down more than a single level.
 * The `convert` option for `ub.hash_data` was previously not hooked up.
 * Correctly expose `dict_diff`
+* Fixed issue in `ub.augpath` where `multidot` did not preserve the original extension
 
 ### Changed
 * `ub.Cacher` no longer ensures that the `dpath` exists on construction. This check is delayed until `save` is called.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 * `ub.Cacher` no longer ensures that the `dpath` exists on construction. This check is delayed until `save` is called.
 * `ub.CacheStamp` now accepts the `enabled` keyword. 
+* `modpath_to_modname` now properly handles compiled modules with ABI tags.
 
 
 ## [Version 0.8.0] - 2019-05-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ We are currently working on porting this changelog to the specifications in
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Version 0.8.1] - Unreleased
+## [Version 0.8.1] - 2019-07-11
 
 ### Added
 * Added `dpath` as an argument to `ub.augpath`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,3 @@
-# tqdm
-numpy
-xxhash >= 1.0.1
-Pygments >= 2.2.0
-six >= 1.10.0
-ordered-set >= 0.3.1
-
-progiter >= 0.1.0
-timerit >= 0.2.0
-
-jaraco.windows >= 3.9.1;platform_system=="Windows"
-xdoctest >= 0.3.0
-pytest >= 3.3.1
-pytest-cov
-coverage >= 4.3.4
+-r requirements/runtime.txt
+-r requirements/optional.txt
+-r requirements/tests.txt

--- a/run_developer_setup.sh
+++ b/run_developer_setup.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 # Install dependency packages
-pip install -r requirements.txt
-pip install -e .
+pip install -r requirements/runtime.txt
+pip install -r requirements/tests.txt
+pip install -r requirements/optional.txt
+
+# new pep makes this not always work
+# pip install -e .
+
+python setup.py develop

--- a/setup.py
+++ b/setup.py
@@ -7,41 +7,6 @@ Installation:
 Developing:
     git clone https://github.com/Erotemic/ubelt.git
     pip install -e ubelt
-
-Pypi:
-     # Presetup
-     pip install twine
-
-     # First tag the source-code
-     VERSION=$(python -c "import setup; print(setup.version)")
-     echo $VERSION
-     git tag $VERSION -m "tarball tag $VERSION"
-     git push --tags origin master
-
-     # NEW API TO UPLOAD TO PYPI
-     # https://packaging.python.org/tutorials/distributing-packages/
-
-     # Build wheel or source distribution
-     python setup.py bdist_wheel --universal
-
-     # Use twine to upload. This will prompt for username and password
-     # If you get an error:
-     #   403 Client Error: Invalid or non-existent authentication information.
-     # simply try typing your password slower.
-     twine upload --username erotemic --skip-existing dist/*
-
-     # Check the url to make sure everything worked
-     https://pypi.org/project/ubelt/
-
-     # ---------- OLD ----------------
-     # Check the url to make sure everything worked
-     https://pypi.python.org/pypi?:action=display&name=ubelt
-
-
-Update Requirments:
-    # Requirements are broken down by type in the `requirements` folder, and
-    # `requirments.txt` lists them all. Thus we autogenerate via:
-    cat requirements/*.txt > requirements.txt
 """
 from setuptools import setup
 import sys
@@ -133,23 +98,30 @@ def parse_requirements(fname='requirements.txt'):
     CommandLine:
         python -c "import setup; print(setup.parse_requirements())"
     """
-    from os.path import dirname, join, exists
+    from os.path import exists
     import re
-    require_fpath = join(dirname(__file__), fname)
+    require_fpath = fname
 
     def parse_line(line):
         """
         Parse information from a line in a requirements text file
         """
-        info = {}
-        if line.startswith('-e '):
+        if line.startswith('-r '):
+            # Allow specifying requirements in other files
+            target = line.split(' ')[1]
+            for info in parse_require_file(target):
+                yield info
+        elif line.startswith('-e '):
+            info = {}
             info['package'] = line.split('#egg=')[1]
+            yield info
         else:
             # Remove versioning from the package
             pat = '(' + '|'.join(['>=', '==', '>']) + ')'
             parts = re.split(pat, line, maxsplit=1)
             parts = [p.strip() for p in parts]
 
+            info = {}
             info['package'] = parts[0]
             if len(parts) > 1:
                 op, rest = parts[1:]
@@ -161,25 +133,28 @@ def parse_requirements(fname='requirements.txt'):
                 else:
                     version = rest  # NOQA
                 info['version'] = (op, version)
-        return info
+            yield info
 
-    # This breaks on pip install, so check that it exists.
-    if exists(require_fpath):
-        with open(require_fpath, 'r') as f:
-            packages = []
+    def parse_require_file(fpath):
+        with open(fpath, 'r') as f:
             for line in f.readlines():
                 line = line.strip()
                 if line and not line.startswith('#'):
-                    info = parse_line(line)
-                    package = info['package']
-                    if not sys.version.startswith('3.4'):
-                        # apparently package_deps are broken in 3.4
-                        platform_deps = info.get('platform_deps')
-                        if platform_deps is not None:
-                            package += ';' + platform_deps
-                    packages.append(package)
-            return packages
-    return []
+                    for info in parse_line(line):
+                        yield info
+
+    # This breaks on pip install, so check that it exists.
+    packages = []
+    if exists(require_fpath):
+        for info in parse_require_file(require_fpath):
+            package = info['package']
+            if not sys.version.startswith('3.4'):
+                # apparently package_deps are broken in 3.4
+                platform_deps = info.get('platform_deps')
+                if platform_deps is not None:
+                    package += ';' + platform_deps
+            packages.append(package)
+    return packages
 
 
 version = parse_version('ubelt')  # needs to be a global var for git tags

--- a/ubelt/util_colors.py
+++ b/ubelt/util_colors.py
@@ -28,7 +28,7 @@ def highlight_code(text, lexer_name='python', **kwargs):
 
     Args:
         text (str): plain text to highlight
-        lexer_name (str): name of language
+        lexer_name (str): name of language. eg: python, docker, c++
         **kwargs: passed to pygments.lexers.get_lexer_by_name
 
     Returns:
@@ -37,6 +37,7 @@ def highlight_code(text, lexer_name='python', **kwargs):
 
     CommandLine:
         python -c "import pygments.formatters; print(list(pygments.formatters.get_all_formatters()))"
+        python -c "import pygments.lexers, ubelt; print(ubelt.repr2(pygments.lexers.__all__, nl=2))"
 
     Example:
         >>> import ubelt as ub

--- a/ubelt/util_download.py
+++ b/ubelt/util_download.py
@@ -70,6 +70,9 @@ def download(url, fpath=None, hash_prefix=None, hasher='sha512',
         .. [3] http://stackoverflow.com/questions/16694907/how-to-download-large-file-in-python-with-requests-py
         .. [4] https://github.com/pytorch/pytorch/blob/2787f1d8edbd4aadd4a8680d204341a1d7112e2d/torch/hub.py#L347
 
+    TODO:
+        - [ ] fine-grained control of progress
+
     CommandLine:
         python -m xdoctest ubelt.util_download download:1
 

--- a/ubelt/util_download.py
+++ b/ubelt/util_download.py
@@ -27,7 +27,12 @@ __all__ = ['download', 'grabdata']
 def download(url, fpath=None, hash_prefix=None, hasher='sha512',
              chunksize=8192, verbose=1):
     """
-    downloads a url to a fpath.
+    Downloads a url to a file on disk.
+
+    If unspecified the location and name of the file is chosen automatically.
+    A hash_prefix can be specified to verify the integrity of the downloaded
+    data. This function will download the data every time its called. For
+    cached downloading see `grabdata`.
 
     Args:
         url (str):
@@ -39,22 +44,22 @@ def download(url, fpath=None, hash_prefix=None, hasher='sha512',
             is directly written to this object (note this prevents the use of
             temporary files).
 
-        hash_prefix (None or str):
+        hash_prefix (None | str):
             If specified, download will retry / error if the file hash
             does not match this value. Defaults to None.
 
-        hasher (str or Hasher):
+        hasher (str | Hasher):
             If hash_prefix is specified, this indicates the hashing
             algorithm to apply to the file. Defaults to sha512.
 
-        chunksize (int):
-            Download chunksize. Defaults to 2 ** 13.
+        chunksize (int, default=2 ** 13):
+            Download chunksize.
 
-        verbose (int):
-            Verbosity level 0 or 1. Defaults to 1.
+        verbose (int, default=1):
+            Verbosity level 0 or 1.
 
     Returns:
-        PathLike: fpath - file path string
+        PathLike: fpath - path to the downloaded file.
 
     Raises:
         URLError - if there is problem downloading the url
@@ -72,9 +77,6 @@ def download(url, fpath=None, hash_prefix=None, hasher='sha512',
 
     TODO:
         - [ ] fine-grained control of progress
-
-    CommandLine:
-        python -m xdoctest ubelt.util_download download:1
 
     Example:
         >>> # xdoctest: +REQUIRES(--network)
@@ -226,6 +228,10 @@ def grabdata(url, fpath=None, dpath=None, fname=None, redo=False,
     """
     Downloads a file, caches it, and returns its local path.
 
+    If unspecified the location and name of the file is chosen automatically.
+    A hash_prefix can be specified to verify the integrity of the downloaded
+    data.
+
     Args:
         url (str): url to the file to download
 
@@ -239,26 +245,26 @@ def grabdata(url, fpath=None, dpath=None, fname=None, redo=False,
         fname (str): What to name the downloaded file. Defaults to the url
             basename. Mutually exclusive with fpath.
 
-        redo (bool): if True forces redownload of the file (default = False)
+        redo (bool, default=False): if True forces redownload of the file
 
-        verbose (bool):  verbosity flag (default = True)
+        verbose (bool, default=True):  verbosity flag
 
         appname (str): set dpath to `ub.get_app_cache_dir(appname)`.
             Mutually exclusive with dpath and fpath.
 
-        hash_prefix (None or str):
+        hash_prefix (None | str):
             If specified, grabdata verifies that this matches the hash of the
             file, and then saves the hash in a adjacent file to certify that
             the download was successful. Defaults to None.
 
-        hasher (str or Hasher):
+        hasher (str | Hasher):
             If hash_prefix is specified, this indicates the hashing
             algorithm to apply to the file. Defaults to sha512.
 
         **download_kw: additional kwargs to pass to ub.download
 
     Returns:
-        PathLike: fpath - file path string
+        PathLike: fpath - path to downloaded or cached file.
 
     Example:
         >>> # xdoctest: +REQUIRES(--network)

--- a/ubelt/util_hash.py
+++ b/ubelt/util_hash.py
@@ -402,16 +402,16 @@ class HashableExtensions(object):
         try:
             hash_type, hash_func = self.keyed_extensions[key]
         except KeyError:
-            if issubclass(query_hash_type, dict):
-                # TODO: In Python 3.7+ dicts are ordered by default, so
-                # perhaps we should allow hashing them by default
-                import warnings
-                warnings.warn(
-                    'It looks like you are trying to hash an unordered dict. '
-                    'By default this is not allowed, but if you REALLY need '
-                    'to do this, then call '
-                    'ubelt.util_hash._HASHABLE_EXTENSIONS._register_agressive_extensions() '
-                    'beforehand')
+            # if issubclass(query_hash_type, dict):
+            #     # TODO: In Python 3.7+ dicts are ordered by default, so
+            #     # perhaps we should allow hashing them by default
+            #     import warnings
+            #     warnings.warn(
+            #         'It looks like you are trying to hash an unordered dict. '
+            #         'By default this is not allowed, but if you REALLY need '
+            #         'to do this, then call '
+            #         'ubelt.util_hash._HASHABLE_EXTENSIONS._register_agressive_extensions() '
+            #         'beforehand')
             raise TypeError(
                 'No registered hash func for hashable type={!r}'.format(
                     query_hash_type))

--- a/ubelt/util_list.py
+++ b/ubelt/util_list.py
@@ -176,7 +176,8 @@ def iterable(obj, strok=False):
     Args:
         obj (object): a scalar or iterable input
 
-        strok (bool): if True allow strings to be interpreted as iterable
+        strok (bool, default=False):
+            if True allow strings to be interpreted as iterable
 
     Returns:
         bool: True if the input is iterable

--- a/ubelt/util_path.py
+++ b/ubelt/util_path.py
@@ -99,7 +99,7 @@ def augpath(path, suffix='', prefix='', ext=None, base=None, dpath=None,
     orig_dpath, fname = split(path)
     if multidot:
         # The first dot defines the extension
-        parts = fname.split('.', maxsplit=1)
+        parts = fname.rsplit('.', 1)
         orig_base = parts[0]
         orig_ext = '' if len(parts) == 1 else '.' + parts[1]
     else:

--- a/ubelt/util_path.py
+++ b/ubelt/util_path.py
@@ -99,7 +99,7 @@ def augpath(path, suffix='', prefix='', ext=None, base=None, dpath=None,
     orig_dpath, fname = split(path)
     if multidot:
         # The first dot defines the extension
-        parts = fname.rsplit('.', 1)
+        parts = fname.split('.', 1)
         orig_base = parts[0]
         orig_ext = '' if len(parts) == 1 else '.' + parts[1]
     else:

--- a/ubelt/util_path.py
+++ b/ubelt/util_path.py
@@ -57,9 +57,9 @@ def augpath(path, suffix='', prefix='', ext=None, base=None, dpath=None,
         path (PathLike): a path to augment
         suffix (str, default=''): placed between the basename and extension
         prefix (str, default=''): placed in front of the basename
-        ext (str): if specified, replaces the extension
-        base (str): if specified, replaces the basename (without extension)
-        dpath (PathLike): if specified, replaces the directory
+        ext (str, optional): if specified, replaces the extension
+        base (str, optional): if specified, replaces the basename without extension
+        dpath (PathLike, optional): if specified, replaces the directory
         multidot (bool, default=False): if False, everything after the last dot
             in the basename is the extension. If True, everything after the first
             dot in the basename is the extension.
@@ -183,9 +183,6 @@ def compressuser(path, home='~'):
     Returns:
         PathLike: path: shortened path replacing the home directory with a tilde
 
-    CommandLine:
-        xdoctest -m ubelt.util_path compressuser
-
     Example:
         >>> path = expanduser('~')
         >>> assert path != '~'
@@ -246,9 +243,6 @@ def truepath(path, real=False):
 
         On windows expanduser will expand environment variables formatted as
         %name%, whereas on unix, this will not occur.
-
-    CommandLine:
-        python -m ubelt.util_path truepath
 
     Example:
         >>> import ubelt as ub

--- a/ubelt/util_path.py
+++ b/ubelt/util_path.py
@@ -65,6 +65,9 @@ def augpath(path, suffix='', prefix='', ext=None, base=None, multidot=False):
     CommandLine:
         python -m ubelt.util_path augpath
 
+    TODO:
+        - [ ] Should there be an option to change the dpath/dirname?
+
     Example:
         >>> import ubelt as ub
         >>> path = 'foo.bar'


### PR DESCRIPTION
Its probably better if the real util_import code lived in ubelt and xdoctest was the one to use closures to "statically" port the code. 