### PR TITLE
Reword ensuredir verbosity message

### DIFF
--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -55,8 +55,31 @@ def test_augpath_dpath():
 
 
 def test_ensuredir_recreate():
-    ub.ensuredir('foo', recreate=True)
-    ub.ensuredir('foo/bar')
-    assert exists('foo/bar')
-    ub.ensuredir('foo', recreate=True)
-    assert not exists('foo/bar')
+    base = ub.ensure_app_cache_dir('ubelt/tests')
+    folder = join(base, 'foo')
+    member = join(folder, 'bar')
+    ub.ensuredir(folder, recreate=True)
+    ub.ensuredir(member)
+    assert exists(member)
+    ub.ensuredir(folder, recreate=True)
+    assert not exists(member)
+
+
+def test_ensuredir_verbosity():
+    base = ub.ensure_app_cache_dir('ubelt/tests')
+
+    with ub.CaptureStdout() as cap:
+        ub.ensuredir(join(base, 'foo'), verbose=0)
+    assert cap.text == ''
+    # None defaults to verbose=0
+    with ub.CaptureStdout() as cap:
+        ub.ensuredir((base, 'foo'), verbose=None)
+    assert cap.text == ''
+
+    ub.delete(join(base, 'foo'))
+    with ub.CaptureStdout() as cap:
+        ub.ensuredir(join(base, 'foo'), verbose=1)
+    assert 'creating' in cap.text
+    with ub.CaptureStdout() as cap:
+        ub.ensuredir(join(base, 'foo'), verbose=1)
+    assert 'existing' in cap.text

--- a/ubelt/util_path.py
+++ b/ubelt/util_path.py
@@ -291,9 +291,9 @@ def ensuredir(dpath, mode=0o1777, verbose=None, recreate=False):
         >>> assert exists(dpath)
         >>> os.rmdir(dpath)
     """
-    if verbose is None:  # nocover
+    if verbose is None:
         verbose = 0
-    if isinstance(dpath, (list, tuple)):  # nocover
+    if isinstance(dpath, (list, tuple)):
         dpath = join(*dpath)
 
     if recreate:
@@ -301,15 +301,15 @@ def ensuredir(dpath, mode=0o1777, verbose=None, recreate=False):
         ub.delete(dpath, verbose=verbose)
 
     if not exists(dpath):
-        if verbose:  # nocover
-            print('Ensuring new directory (%r)' % dpath)
+        if verbose:
+            print('Ensuring directory (creating {!r})'.format(dpath))
         if sys.version_info.major == 2:  # nocover
             os.makedirs(normpath(dpath), mode=mode)
         else:
             os.makedirs(normpath(dpath), mode=mode, exist_ok=True)
     else:
-        if verbose:  # nocover
-            print('Ensuring existing directory (%r)' % dpath)
+        if verbose:
+            print('Ensuring directory (existing {!r})'.format(dpath))
     return dpath
 
 


### PR DESCRIPTION
quick change of wording to make ensuredir stdout messages more clear.

Fixes #54