### PR TITLE
Fix import error when Python doesnt have OpenSSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ We are currently working on porting this changelog to the specifications in
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Version 0.8.7] - 2019-12-06
+
+### Fixed
+* Fixed corner case where `util_hash` raised an import error when python was
+  not compiled with OpenSSL.
+
 ## [Version 0.8.6] - 2019-12-05
 
 ### Fixed

--- a/ubelt/__init__.py
+++ b/ubelt/__init__.py
@@ -22,7 +22,7 @@ Testing:
     xdoctest ubelt
 """
 
-__version__ = '0.8.6'
+__version__ = '0.8.7'
 
 __submodules__ = [
     'util_arg',


### PR DESCRIPTION
I followed these instructions to compile python without OpenSSL: https://stackoverflow.com/a/21788773

When testing with a Python compiled without OpenSSL we got this error:

```python
(py37) joncrall@namek:~/code/ubelt$ ../cpython/python -c "import ubelt"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/joncrall/code/ubelt/ubelt/__init__.py", line 67, in <module>
    from ubelt import util_hash
  File "/home/joncrall/code/ubelt/ubelt/util_hash.py", line 148, in <module>
    HASH = hashlib._hashlib.HASH
AttributeError: module 'hashlib' has no attribute '_hashlib'
(py37) joncrall@namek:~/code/ubelt$ kjkg^C
(py37) joncrall@namek:~/code/ubelt$ ../cpython/python -c "import ubelt"
Traceback (most recent call last):
  File "/home/joncrall/code/ubelt/ubelt/util_hash.py", line 149, in <module>
    HASH = hashlib._hashlib.HASH
AttributeError: module 'hashlib' has no attribute '_hashlib'
```