### PR TITLE
datetime precision and JobQueue join

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ ENV/
 profile_output.*
 _skbuild
 pip-wheel-metadata/
+
+wheelhouse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * `ub.timestamp` can now accept a datetime object as an argument, and will return 
    the timestamp for that object.
 * `ub.Path.ls` a convenience function that aliases `list(path.iterdir())`.
+* `ub.Path.walk` to wrap `os.walk`. 
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   and returns a list of results.
 * `ub.timestamp` can now accept a datetime object as an argument, and will return 
    the timestamp for that object.
+* `ub.Path.ls` a convenience function that aliases `list(path.iterdir())`.
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * `ub.cmd` now accepts a `timeout` argument (tee support is pending).
 * `ub.JobPool` now contains a protected `_prog` variable allowing the user
   finer-grained progress controls.
+* `ub.JobPool` now contains a convenience method `join` that executes all jobs
+  and returns a list of results.
+* `ub.timestamp` can now accept a datetime object as an argument, and will return 
+   the timestamp for that object.
+
 
 ### Changed
 * Register `pathlib.Path` with `ub.repr2`
@@ -21,12 +26,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 * `ub.hash_data` now recognizes subclasses of registered types.
+* `ub.timestamp()` has been outputting incorrect (negated) UTC offsets. This is now fixed.
 
 ### Changed
 * The `ubelt.util_hash.HashableExtensions` implementation was updated to use
   `functools.singledispatch` instead of the custom solution. This seems faster
   and should not have any API impact.
-
 
 
 ## Version 1.0.1 - Released 2022-02-20

--- a/dev/gen_typed_stubs.py
+++ b/dev/gen_typed_stubs.py
@@ -285,6 +285,9 @@ class ExtendedStubGenerator(StubGenerator):
             if 'io.' in info['type']:
                 self.add_import_line('import io\n')
 
+            if 'datetime.' in info['type']:
+                self.add_import_line('import datetime\n')
+
             if '|' in info['type']:
                 self.add_typing_import('Union')
                 self.add_import_line('from typing import {}\n'.format('Union'))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -159,6 +159,15 @@ def test_cache_depends():
     cfgstr = cacher._rectify_cfgstr()
     assert cfgstr.startswith('8a82eef87cb905220841f95')
 
+
+def test_cache_cfgstr():
+    """
+    TODO: remove when cfgstr is removed
+    """
+    with pytest.warns(DeprecationWarning):
+        cacher1 = ub.Cacher('name', cfgstr='abc')
+    assert cacher1.depends == 'abc'
+
 if __name__ == '__main__':
     r"""
     CommandLine:

--- a/tests/test_cache_stamp.py
+++ b/tests/test_cache_stamp.py
@@ -8,7 +8,7 @@ def test_cache_stamp():
     ub.delete(dpath)
     ub.ensuredir(dpath)
     product = join(dpath, 'expensive-to-compute.txt')
-    self = ub.CacheStamp('test1', dpath=dpath, cfgstr='test1',
+    self = ub.CacheStamp('test1', dpath=dpath, depends='test1',
                          product=product, hasher=None)
     if self.expired():
         ub.writeto(product, 'very expensive')
@@ -32,7 +32,7 @@ def test_cache_stamp_corrupt_product_nohasher():
     ub.delete(dpath)
     ub.ensuredir(dpath)
     product = join(dpath, name + '.txt')
-    self = ub.CacheStamp(name, dpath=dpath, cfgstr=name, product=product,
+    self = ub.CacheStamp(name, dpath=dpath, depends=name, product=product,
                          hasher=None)
     if self.expired():
         ub.writeto(product, 'very expensive')
@@ -49,7 +49,7 @@ def test_cache_stamp_corrupt_product_hasher():
     ub.delete(dpath)
     ub.ensuredir(dpath)
     product = join(dpath, name + '.txt')
-    self = ub.CacheStamp(name, dpath=dpath, cfgstr=name, product=product,
+    self = ub.CacheStamp(name, dpath=dpath, depends=name, product=product,
                          hasher='sha1')
     if self.expired():
         ub.writeto(product, 'very expensive')
@@ -71,7 +71,7 @@ def test_cache_stamp_multiproduct():
         join(dpath, 'product2.txt'),
         join(dpath, 'product3.txt'),
     ]
-    self = ub.CacheStamp('somedata', dpath=dpath, cfgstr='someconfig',
+    self = ub.CacheStamp('somedata', dpath=dpath, depends='someconfig',
                          product=product)
     if self.expired():
         for fpath in product:
@@ -90,7 +90,7 @@ def test_cache_stamp_noproduct():
     ub.ensuredir(dpath)
     name = 'noproduct'
     product = join(dpath, name + '.txt')
-    self = ub.CacheStamp('somedata', dpath=dpath, cfgstr='someconfig', product=None)
+    self = ub.CacheStamp('somedata', dpath=dpath, depends='someconfig', product=None)
     if self.expired():
         ub.writeto(product, 'very expensive')
         self.renew()

--- a/ubelt/util_dict.pyi
+++ b/ubelt/util_dict.pyi
@@ -12,9 +12,9 @@ from collections.abc import Generator
 from typing import Any, TypeVar
 from ubelt import util_const
 
-T = TypeVar("T")
 KT = TypeVar("KT")
 VT = TypeVar("VT")
+T = TypeVar("T")
 odict = OrderedDict
 ddict = defaultdict
 

--- a/ubelt/util_dict.pyi
+++ b/ubelt/util_dict.pyi
@@ -12,9 +12,9 @@ from collections.abc import Generator
 from typing import Any, TypeVar
 from ubelt import util_const
 
-VT = TypeVar("VT")
 T = TypeVar("T")
 KT = TypeVar("KT")
+VT = TypeVar("VT")
 odict = OrderedDict
 ddict = defaultdict
 

--- a/ubelt/util_futures.py
+++ b/ubelt/util_futures.py
@@ -431,6 +431,38 @@ class JobPool(object):
         for job in job_iter:
             yield job
 
+    def join(self, **kwargs):
+        """
+        Like :method:`JobPool.as_completed`, but executes the `result` method
+        of each future and returns only after all processes are complete.
+        This allows for lower-boilerplate prototyping.
+
+        Args:
+            **kwargs: passed to :method:`JobPool.as_completed`
+
+        Example:
+            >>> import ubelt as ub
+            >>> # We just want to try replacing our simple iterative algorithm
+            >>> # with the embarassingly parallel version
+            >>> arglist = list(zip(range(1000), range(1000)))
+            >>> func = ub.identity
+            >>> #
+            >>> # Original version
+            >>> for args in arglist:
+            >>>     func(*args)
+            >>> #
+            >>> # Potentially parallel version
+            >>> jobs = ub.JobPool(max_workers=0)
+            >>> for args in arglist:
+            >>>     jobs.submit(func, *args)
+            >>> _ = jobs.join(desc='running')
+        """
+        results = []
+        for job in self.as_completed(**kwargs):
+            result = job.result()
+            results.append(result)
+        return results
+
     def __iter__(self):
         """
         An alternative to as completed

--- a/ubelt/util_futures.py
+++ b/ubelt/util_futures.py
@@ -440,6 +440,9 @@ class JobPool(object):
         Args:
             **kwargs: passed to :method:`JobPool.as_completed`
 
+        Returns:
+            List[Any]: list of results
+
         Example:
             >>> import ubelt as ub
             >>> # We just want to try replacing our simple iterative algorithm

--- a/ubelt/util_futures.pyi
+++ b/ubelt/util_futures.pyi
@@ -1,6 +1,7 @@
 import concurrent.futures
 from typing import Callable
 from typing import Union
+from typing import List
 import concurrent.futures
 from collections.abc import Generator
 from typing import Any
@@ -89,6 +90,9 @@ class JobPool:
         desc: Union[str, None] = ...,
         progkw: Union[dict, None] = ...
     ) -> Generator[concurrent.futures.Future, None, None]:
+        ...
+
+    def join(self, **kwargs) -> List[Any]:
         ...
 
     def __iter__(self):

--- a/ubelt/util_list.pyi
+++ b/ubelt/util_list.pyi
@@ -8,9 +8,9 @@ from typing import List
 from collections.abc import Generator
 from typing import Any, TypeVar
 
-T = TypeVar("T")
 KT = TypeVar("KT")
 VT = TypeVar("VT")
+T = TypeVar("T")
 
 
 class chunks:

--- a/ubelt/util_list.pyi
+++ b/ubelt/util_list.pyi
@@ -8,9 +8,9 @@ from typing import List
 from collections.abc import Generator
 from typing import Any, TypeVar
 
-VT = TypeVar("VT")
 T = TypeVar("T")
 KT = TypeVar("KT")
+VT = TypeVar("VT")
 
 
 class chunks:

--- a/ubelt/util_path.py
+++ b/ubelt/util_path.py
@@ -410,6 +410,7 @@ class Path(_PathBase):
         ~/.cache/ubelt/demo_path/text_file.aux.jpg
         ~/.cache/ubelt/demo_pathdemo_path2
     """
+    __slots__ = ()
 
     def touch(self, mode=0o666, exist_ok=True):
         """
@@ -638,3 +639,35 @@ class Path(_PathBase):
             return cls(util_platform.get_app_data_dir(appname, *args))
         else:
             raise KeyError(type)
+
+    def ls(self):
+        """
+        A convenience function to list all paths in a directory.
+
+        This is simply a wraper around iterdir that returns the results as a
+        list instead of a generator. This is mainly for faster navigation in
+        IPython. In production code `iterdir` should be used instead.
+
+        Returns:
+            List[Path]
+
+        Example:
+            >>> import ubelt as ub
+            >>> self = ub.Path.appdir('ubelt/tests/ls')
+            >>> (self / 'dir1').ensuredir()
+            >>> (self / 'dir2').ensuredir()
+            >>> (self / 'file1').touch()
+            >>> (self / 'file2').touch()
+            >>> (self / 'dir1/file3').touch()
+            >>> (self / 'dir2/file4').touch()
+            >>> children = self.ls()
+            >>> assert isinstance(children, list)
+            >>> print(ub.repr2(sorted([p.relative_to(self) for p in children])))
+            [
+                Path('dir1'),
+                Path('dir2'),
+                Path('file1'),
+                Path('file2'),
+            ]
+        """
+        return list(self.iterdir())

--- a/ubelt/util_path.py
+++ b/ubelt/util_path.py
@@ -671,3 +671,42 @@ class Path(_PathBase):
             ]
         """
         return list(self.iterdir())
+
+    def walk(self, topdown=True, onerror=None, followlinks=False):
+        """
+        A variant of os.walk for pathlib
+
+        Args:
+            topdown (bool):
+                if True starts yield nodes closer to the root first otherwise
+                yield nodes closer to the leaves first.
+
+            onerror (callable):
+                A function with one argument of type OSError. If the
+                error is raised the walk is aborted, otherwise it continues.
+
+            followlinks (bool):
+                if True recurse into symbolic directory links
+
+        Yields:
+            Tuple[Path, str, str]: the root, file names, and directory names
+
+        Example:
+            >>> import ubelt as ub
+            >>> self = ub.Path.appdir('ubelt/tests/ls')
+            >>> (self / 'dir1').ensuredir()
+            >>> (self / 'dir2').ensuredir()
+            >>> (self / 'file1').touch()
+            >>> (self / 'file2').touch()
+            >>> (self / 'dir1/file3').touch()
+            >>> (self / 'dir2/file4').touch()
+            >>> subdirs = list(self.walk())
+            >>> assert len(subdirs) == 3
+        """
+        import os
+        cls = self.__class__
+        walker = os.walk(self, topdown=topdown, onerror=onerror,
+                         followlinks=followlinks)
+        for r, fs, ds in walker:
+            r = cls(r)
+            yield r, fs, ds

--- a/ubelt/util_path.pyi
+++ b/ubelt/util_path.pyi
@@ -94,3 +94,6 @@ class Path:
     @classmethod
     def appdir(cls, appname: str, *args, type: str = ...) -> 'Path':
         ...
+
+    def ls(self):
+        ...

--- a/ubelt/util_time.py
+++ b/ubelt/util_time.py
@@ -50,17 +50,17 @@ def timestamp(datetime=None, precision=0, method='iso8601'):
         >>> from datetime import datetime as datetime_cls
         >>> # Create a datetime object with timezone information
         >>> ast_tzinfo = datetime_mod.timezone(datetime_mod.timedelta(hours=-4), 'AST')
-        >>> datetime = datetime_cls.fromtimestamp(123456789.123456789).replace(tzinfo=ast_tzinfo)
+        >>> datetime = datetime_cls.utcfromtimestamp(123456789.123456789).replace(tzinfo=ast_tzinfo)
         >>> stamp = ub.timestamp(datetime, precision=2)
         >>> print('stamp = {!r}'.format(stamp))
-        stamp = '1973-11-29T163309.12-4'
+        stamp = '1973-11-29T213309.12-4'
 
         >>> # Demo with a fractional hour timezone
         >>> act_tzinfo = datetime_mod.timezone(datetime_mod.timedelta(hours=+9.5), 'ACT')
-        >>> datetime = datetime_cls.fromtimestamp(123456789.123456789).replace(tzinfo=act_tzinfo)
+        >>> datetime = datetime_cls.utcfromtimestamp(123456789.123456789).replace(tzinfo=act_tzinfo)
         >>> stamp = ub.timestamp(datetime, precision=2)
         >>> print('stamp = {!r}'.format(stamp))
-        stamp = '1973-11-29T163309.12+0930'
+        stamp = '1973-11-29T213309.12+0930'
 
     Ignore:
         >>> # xdoctest: +REQUIRES(module:dateutil)
@@ -78,8 +78,8 @@ def timestamp(datetime=None, precision=0, method='iso8601'):
         >>>     dateutil.tz.tzlocal()
         >>> ]
         >>> datetime_list = [
-        >>>     datetime_cls.fromtimestamp(123456789.123456789),
-        >>>     datetime_cls.fromtimestamp(0),
+        >>>     datetime_cls.utcfromtimestamp(123456789.123456789),
+        >>>     datetime_cls.utcfromtimestamp(0),
         >>> ]
         >>> basis = {
         >>>     #'precision': [0, 3, 9],

--- a/ubelt/util_time.py
+++ b/ubelt/util_time.py
@@ -17,11 +17,16 @@ __all__ = ['timestamp', 'Timer']
 
 def timestamp(datetime=None, precision=0, method='iso8601'):
     """
-    Make an iso8601 timestamp suitable for use in filenames
+    Make a concise iso8601 timestamp suitable for use in filenames
 
     Args:
+        datetime (datetime.datetime | None):
+            A datetime to format into a timestamp. If unspecified, the current
+            local time is used.
+
         method (str):
             Type of timestamp. Currently the only option is iso8601.
+            This argument may be removed in the future.
 
         precision (int):
             if non-zero, adds up to 6 digits of sub-second precision.
@@ -103,9 +108,6 @@ def timestamp(datetime=None, precision=0, method='iso8601'):
         >>>     assert int(dtime.timestamp() * shift) == int(recon.timestamp() * shift)
     """
     if method == 'iso8601':
-        # ISO 8601
-        # datetime.datetime.utcnow().isoformat()
-        # utcnow
         from datetime import datetime as datetime_cls
         if datetime is None:
             datetime = datetime_cls.now()

--- a/ubelt/util_time.py
+++ b/ubelt/util_time.py
@@ -46,41 +46,96 @@ def timestamp(datetime=None, precision=0, method='iso8601'):
 
     Example:
         >>> import ubelt as ub
-        >>> stamp = ub.timestamp(precision=2)
+        >>> import datetime as datetime_mod
+        >>> from datetime import datetime as datetime_cls
+        >>> # Create a datetime object with timezone information
+        >>> ast_tzinfo = datetime_mod.timezone(datetime_mod.timedelta(hours=-4), 'AST')
+        >>> datetime = datetime_cls.fromtimestamp(123456789.123456789).replace(tzinfo=ast_tzinfo)
+        >>> stamp = ub.timestamp(datetime, precision=2)
         >>> print('stamp = {!r}'.format(stamp))
-        stamp = ...-...-...T.......
+        stamp = '1973-11-29T163309.12-4'
+
+        >>> # Demo with a fractional hour timezone
+        >>> act_tzinfo = datetime_mod.timezone(datetime_mod.timedelta(hours=+9.5), 'ACT')
+        >>> datetime = datetime_cls.fromtimestamp(123456789.123456789).replace(tzinfo=act_tzinfo)
+        >>> stamp = ub.timestamp(datetime, precision=2)
+        >>> print('stamp = {!r}'.format(stamp))
+        stamp = '1973-11-29T163309.12+0930'
 
     Ignore:
-        # Make sure we are compatible with dateutil
-        from dateutil import parser
-        from ubelt.util_time import *  # NOQA
-        print(timestamp(precision=0))
-        print(timestamp(precision=1))
-        print(timestamp(precision=2))
-        print(timestamp(precision=6))
-        print(timestamp(precision=9))
+        >>> # xdoctest: +REQUIRES(module:dateutil)
+        >>> # Make sure we are compatible with dateutil
+        >>> import dateutil
+        >>> from dateutil import parser
+        >>> import datetime as datetime_mod
+        >>> from datetime import datetime as datetime_cls
+        >>> tzinfo_list = [
+        >>>     datetime_mod.timezone(datetime_mod.timedelta(hours=+9.5), 'ACT'),
+        >>>     datetime_mod.timezone(datetime_mod.timedelta(hours=-4), 'AST'),
+        >>>     datetime_mod.timezone(datetime_mod.timedelta(hours=0), 'UTC'),
+        >>>     datetime_mod.timezone.utc,
+        >>>     None,
+        >>>     dateutil.tz.tzlocal()
+        >>> ]
+        >>> datetime_list = [
+        >>>     datetime_cls.fromtimestamp(123456789.123456789),
+        >>>     datetime_cls.fromtimestamp(0),
+        >>> ]
+        >>> basis = {
+        >>>     #'precision': [0, 3, 9],
+        >>>     'tzinfo': tzinfo_list,
+        >>>     'datetime': datetime_list,
+        >>> }
+        >>> import copy
+        >>> for params in ub.named_product(basis):
+        >>>     dtime = params['datetime'].replace(tzinfo=params['tzinfo'])
+        >>>     precision = params.get('precision', 0)
+        >>>     stamp = ub.timestamp(datetime=dtime, precision=precision)
+        >>>     recon = parser.parse(stamp)
+        >>>     alt = recon.strftime('%Y-%m-%dT%H%M%S.%f%z')
+        >>>     print('---')
+        >>>     print('params = {}'.format(ub.repr2(params, nl=1)))
+        >>>     print(f'dtime={dtime}')
+        >>>     print(f'stamp={stamp}')
+        >>>     print(f'recon={recon}')
+        >>>     print(f'alt  ={alt}')
+        >>>     shift = 10 ** precision
+        >>>     assert int(dtime.timestamp() * shift) == int(recon.timestamp() * shift)
     """
     if method == 'iso8601':
         # ISO 8601
         # datetime.datetime.utcnow().isoformat()
-        # datetime.datetime.now().isoformat()
         # utcnow
-        import datetime
-        now = datetime.datetime.now()
-        tz_hour = time.timezone // 3600
-        utc_offset = str(tz_hour) if tz_hour < 0 else '+' + str(tz_hour)
+        from datetime import datetime as datetime_cls
+        if datetime is None:
+            datetime = datetime_cls.now()
+
+        if datetime.tzinfo is None:
+            # Assume the local timezone (time.timezone is negated)
+            offset_seconds = -time.timezone
+        else:
+            offset_seconds = datetime.tzinfo.utcoffset(datetime).total_seconds()
+
+        seconds_per_hour = 3600
+        tz_hour, tz_remain = divmod(offset_seconds, seconds_per_hour)
+        tz_hour = int(tz_hour)
+        if tz_remain:
+            seconds_per_minute = 60
+            tz_min = int(tz_remain // seconds_per_minute)
+            utc_offset = '{:+03d}{:02d}'.format(tz_hour, tz_min)
+        else:
+            utc_offset = str(tz_hour) if tz_hour < 0 else '+' + str(tz_hour)
         if precision > 0:
             fprecision = 6  # microseconds are padded to 6 decimals
-            ms_offset = -max(0, fprecision - precision)
-            local_stamp = now.strftime('%Y-%m-%dT%H%M%S.%f')
-            now.strftime('%z')
+            local_stamp = datetime.strftime('%Y-%m-%dT%H%M%S.%f')
+            ms_offset = len(local_stamp) - max(0, fprecision - precision)
             local_stamp = local_stamp[:ms_offset]
         else:
-            local_stamp = time.strftime('%Y-%m-%dT%H%M%S')
+            local_stamp = datetime.strftime('%Y-%m-%dT%H%M%S')
         stamp = local_stamp + utc_offset
         return stamp
     else:
-        raise ValueError('only iso8601 is accepted for now')
+        raise ValueError('only iso8601 is allowed for method')
 
 
 class Timer(object):

--- a/ubelt/util_time.pyi
+++ b/ubelt/util_time.pyi
@@ -1,7 +1,10 @@
+from typing import Union
 from typing import Any
 
 
-def timestamp(method: str = ...) -> str:
+def timestamp(datetime: Union[datetime.datetime, None] = ...,
+              precision: int = ...,
+              method: str = ...) -> str:
     ...
 
 

--- a/ubelt/util_time.pyi
+++ b/ubelt/util_time.pyi
@@ -1,6 +1,6 @@
+import datetime
 from typing import Union
 from typing import Any
-import datetime
 
 
 def timestamp(datetime: Union[datetime.datetime, None] = ...,

--- a/ubelt/util_time.pyi
+++ b/ubelt/util_time.pyi
@@ -1,5 +1,6 @@
 from typing import Union
 from typing import Any
+import datetime
 
 
 def timestamp(datetime: Union[datetime.datetime, None] = ...,


### PR DESCRIPTION
* `ub.JobPool` now contains a convenience method `join` that executes all jobs
  and returns a list of results.
* `ub.timestamp` can now accept a datetime object as an argument, and will return 
   the timestamp for that object.
* `ub.Path.ls` a convenience function that aliases `list(path.iterdir())`.
* `ub.Path.walk` to wrap `os.walk`. 
