### PR TITLE
Add ub.timeparse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Version 1.1.0 - Unreleased
 
 ### Added
+* New method: `ub.timeparse` can parse the result of `ub.timestamp` into a
+  datetime object. Can optionally use `dateutil.parser.parse` under the hood.
 * `ub.cmd` now has a `system` argument for modularity with `os.system`.
 * `ub.cmd` now accepts a `timeout` argument (tee support is pending).
 * `ub.JobPool` now contains a protected `_prog` variable allowing the user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
    the timestamp for that object.
 * `ub.Path.ls` a convenience function that aliases `list(path.iterdir())`.
 * `ub.Path.walk` to wrap `os.walk`. 
+* `ub.CacheStamp` will now check the mtime and size to quickly check if the products
+  have changed and force expiration.
+* `ub.CacheStamp` now takes an expires keyword arg, which will keep the cache valid 
+  only for the specified amount of time.
 
 ### Changed
 * Register `pathlib.Path` with `ub.repr2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 * New method: `ub.timeparse` can parse the result of `ub.timestamp` into a
-  datetime object. Can optionally use `dateutil.parser.parse` under the hood.
+  `datetime` object. Can optionally use `dateutil.parser.parse` under the hood.
 * `ub.cmd` now has a `system` argument for modularity with `os.system`.
 * `ub.cmd` now accepts a `timeout` argument (tee support is pending).
 * `ub.JobPool` now contains a protected `_prog` variable allowing the user
   finer-grained progress controls.
 * `ub.JobPool` now contains a convenience method `join` that executes all jobs
   and returns a list of results.
-* `ub.timestamp` can now accept a datetime object as an argument, and will return 
+* `ub.timestamp` can now accept a `datetime` object as an argument, and will return 
    the timestamp for that object.
 * `ub.Path.ls` a convenience function that aliases `list(path.iterdir())`.
 * `ub.Path.walk` to wrap `os.walk`. 
-
 
 ### Changed
 * Register `pathlib.Path` with `ub.repr2`
@@ -31,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 * `ub.hash_data` now recognizes subclasses of registered types.
 * `ub.timestamp()` has been outputting incorrect (negated) UTC offsets. This is now fixed.
+* `ub.timestamp()` now works correctly when the year has less than 4 digits.
 
 ### Changed
 * The `ubelt.util_hash.HashableExtensions` implementation was updated to use

--- a/dev/gen_typed_stubs.py
+++ b/dev/gen_typed_stubs.py
@@ -305,6 +305,13 @@ class ExtendedStubGenerator(StubGenerator):
             if 'concurrent.futures.Future' in info['type']:
                 self.add_import_line('import concurrent.futures\n')
 
+            if info['type'].startswith('callable'):
+                # TODO: generalize, allow the "callable" func to be transformed
+                # into the type if given in the docstring
+                self.add_typing_import('Callable')
+                info['type'] = info['type'].replace('callable', 'Callable')
+                self.add_import_line('from typing import {}\n'.format(typing_arg))
+
         name_to_parsed_docstr_info = {}
         return_parsed_docstr_info = None
         fullname = o.name

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -10,3 +10,5 @@ numpy>=1.11.1    ; python_version < '3.4' and python_version >= '2.7'    # Pytho
 xxhash>=1.0.1
 Pygments>=2.2.0
 colorama>=0.4.3;platform_system=="Windows"
+
+python_dateutil>=2.8.1

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -147,7 +147,7 @@ def test_disable():
 
 def test_disabled_cache_stamp():
     stamp = ub.CacheStamp('foo', 'bar', enabled=False)
-    assert stamp.expired() is True, 'disabled cache stamps are always expired'
+    assert stamp.expired() == 'disabled', 'disabled cache stamps are always expired'
 
 
 def test_cache_depends():

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -31,14 +31,139 @@ def test_timer_error():
     try:
         with ub.Timer() as timer:
             raise Exception()
-    except Exception as ex:
+    except Exception:
         pass
     assert timer.elapsed > 0
 
 
-def timestamp_badmethod():
+def test_timestamp_corner_cases():
+    from datetime import datetime as datetime_cls
+    import datetime as datetime_mod
+    datetime = datetime_cls(1, 1, 1, 1, 1, 1, tzinfo=datetime_mod.timezone.utc)
+    stamp = ub.timestamp(datetime)
+    assert stamp == '0001-01-01T010101+0'
+
+
+def test_timestamp_badmethod():
     with pytest.raises(ValueError):
         ub.timestamp(method='not real')
+
+
+def test_timeparse_minimal():
+    # We should always be able to parse these
+    good_stamps = [
+        '2000-11-22T111111.44444Z',
+        '2000-11-22T111111.44444+5',
+        '2000-11-22T111111.44444-05',
+        '2000-11-22T111111.44444-0500',
+        '2000-11-22T111111.44444+0530',
+        '2000-11-22T111111Z',
+        '2000-11-22T111111+5',
+        '2000-11-22T111111+0530',
+    ]
+    for stamp in good_stamps:
+        result = ub.timeparse(stamp, allow_dateutil=0)
+        recon_stamp = ub.timestamp(result, precision=9)
+        recon_result = ub.timeparse(recon_stamp, allow_dateutil=0)
+        print('----')
+        print(f'stamp        = {stamp}')
+        print(f'recon_stamp  = {recon_stamp}')
+        print(f'result       = {result!r}')
+        print(f'recon_result = {recon_result!r}')
+        assert recon_result == result
+
+
+def test_timeparse_with_dateutil():
+    import ubelt as ub
+    # See Also: https://github.com/dateutil/dateutil/blob/master/tests/test_isoparser.py
+    conditional_stamps = [
+        'Thu Sep 25 10:36:28 2003',
+        'Thu Sep 25 2003',
+        '2003-09-25T10:49:41',
+        '2003-09-25T10:49',
+        '2003-09-25T10',
+        '2003-09-25',
+        '20030925T104941',
+        '20030925T1049',
+        '20030925T10',
+        '20030925',
+        '2003-09-25 10:49:41,502',
+        '199709020908',
+        '19970902090807',
+        '09-25-2003',
+        '25-09-2003',
+        '10-09-2003',
+        '10-09-03',
+        '2003.09.25',
+        '09.25.2003',
+        '25.09.2003',
+        '10.09.2003',
+        '10.09.03',
+        '2003/09/25',
+        '09/25/2003',
+        '25/09/2003',
+        '10/09/2003',
+        '10/09/03',
+        '2003 09 25',
+        '09 25 2003',
+        '25 09 2003',
+        '10 09 2003',
+        '10 09 03',
+        '25 09 03',
+        '03 25 Sep',
+        '25 03 Sep',
+        '  July   4 ,  1976   12:01:02   am  ',
+        "Wed, July 10, '96",
+        '1996.July.10 AD 12:08 PM',
+        'July 4, 1976',
+        '7 4 1976',
+        '4 jul 1976',
+        '4 Jul 1976',
+        '7-4-76',
+        '19760704',
+        '0:01:02 on July 4, 1976',
+        'July 4, 1976 12:01:02 am',
+        'Mon Jan  2 04:24:27 1995',
+        '04.04.95 00:22',
+        'Jan 1 1999 11:23:34.578',
+        '950404 122212',
+        '3rd of May 2001',
+        '5th of March 2001',
+        '1st of May 2003',
+        '0099-01-01T00:00:00',
+        '0031-01-01T00:00:00',
+        '20080227T21:26:01.123456789',
+    ]
+
+    for stamp in conditional_stamps:
+        with pytest.raises(ValueError):
+            result = ub.timeparse(stamp, allow_dateutil=False)
+
+    have_dateutil = bool(ub.modname_to_modpath('dateutil'))
+    if have_dateutil:
+        for stamp in conditional_stamps:
+            result = ub.timeparse(stamp)
+            recon_stamp = ub.timestamp(result, precision=6)
+            recon_result = ub.timeparse(recon_stamp)
+            print('----')
+            print(f'stamp        = {stamp}')
+            print(f'recon_stamp  = {recon_stamp}')
+            print(f'result       = {result!r}')
+            print(f'recon_result = {recon_result!r}')
+            assert result == recon_result
+
+
+def test_timeparse_bad_stamps():
+    # We can never parse these types of stamps
+    bad_stamps = [
+        '',
+        'foobar',
+        '0000-00-00T00:00:00.0000+05'
+    ]
+    for stamp in bad_stamps:
+        with pytest.raises(ValueError):
+            ub.timeparse(stamp)
+
 
 if __name__ == '__main__':
     r"""

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -60,6 +60,7 @@ def test_timeparse_minimal():
         '2000-11-22T111111Z',
         '2000-11-22T111111+5',
         '2000-11-22T111111+0530',
+        '2000-11-22T111111',
     ]
     for stamp in good_stamps:
         result = ub.timeparse(stamp, allow_dateutil=0)

--- a/ubelt/__init__.py
+++ b/ubelt/__init__.py
@@ -126,7 +126,7 @@ from ubelt.util_platform import (DARWIN, LINUX, POSIX, WIN32,
 from ubelt.util_str import (codeblock, ensure_unicode, hzcat, indent,
                             paragraph,)
 from ubelt.util_stream import (CaptureStdout, CaptureStream, TeeStringIO,)
-from ubelt.util_time import (Timer, timestamp,)
+from ubelt.util_time import (Timer, timeparse, timestamp,)
 from ubelt.util_zip import (split_archive, zopen,)
 from ubelt.orderedset import (OrderedSet, oset,)
 from ubelt.progiter import (ProgIter,)
@@ -154,9 +154,9 @@ __all__ = ['AutoDict', 'AutoOrderedDict', 'CacheStamp', 'Cacher',
            'platform_cache_dir', 'platform_config_dir', 'platform_data_dir',
            'progiter', 'readfrom', 'repr2', 'shrinkuser', 'sorted_keys',
            'sorted_vals', 'split_archive', 'split_modpath', 'symlink', 'take',
-           'timestamp', 'touch', 'unique', 'unique_flags', 'userhome',
-           'util_arg', 'util_cache', 'util_cmd', 'util_colors', 'util_const',
-           'util_dict', 'util_download', 'util_download_manager',
+           'timeparse', 'timestamp', 'touch', 'unique', 'unique_flags',
+           'userhome', 'util_arg', 'util_cache', 'util_cmd', 'util_colors',
+           'util_const', 'util_dict', 'util_download', 'util_download_manager',
            'util_format', 'util_func', 'util_futures', 'util_hash',
            'util_import', 'util_indexable', 'util_io', 'util_links',
            'util_list', 'util_memoize', 'util_mixins', 'util_path',

--- a/ubelt/util_cache.py
+++ b/ubelt/util_cache.py
@@ -944,7 +944,7 @@ class CacheStamp(object):
             >>> dpath = ub.Path.appdir('ubelt/tests/cache-stamp-expires')
             >>> self = ub.CacheStamp('myname', depends='myconfig', dpath=dpath)
             >>> # Test str input
-            >>> self.expires = '2020-01-01'
+            >>> self.expires = '2020-01-01T000000Z'
             >>> assert self._expires().replace(tzinfo=None).isoformat() == '2020-01-01T00:00:00'
             >>> # Test datetime input
             >>> dt = ub.timeparse(ub.timestamp())
@@ -999,7 +999,7 @@ class CacheStamp(object):
             >>>                      product=product)
             >>> cert = self._new_certificate()
             >>> assert cert['expires'] is None
-            >>> self.expires = '2020-01-01'
+            >>> self.expires = '2020-01-01T000000'
             >>> self.renew()
             >>> cert = self._new_certificate()
             >>> assert cert['expires'] is not None

--- a/ubelt/util_cache.py
+++ b/ubelt/util_cache.py
@@ -740,25 +740,13 @@ class CacheStamp(object):
         >>> dpath.delete().ensuredir()
         >>> product = dpath / 'expensive-to-compute.txt'
         >>> self = ub.CacheStamp('somedata', depends='someconfig', dpath=dpath,
-        >>>                      product=product, hasher=None)
-        >>> self.hasher = None
+        >>>                      product=product, hasher='sha256')
         >>> if self.expired():
         >>>     product.write_text('very expensive')
         >>>     self.renew()
         >>> assert not self.expired()
-        >>> # corrupting the output will not expire in non-robust mode
-        >>> product.write_text('corrupted')
-        >>> # note: as of version 1.1.0 we also have to disable the new size and
-        >>> # mtime checks to get a non-robust mode.
-        >>> self.expire_checks['size'] = False
-        >>> self.expire_checks['mtime'] = False
-        >>> assert not self.expired()
-        >>> self.hasher = 'sha1'
-        >>> # but it will expire if we are in robust mode
-        >>> assert self.expired()
-        >>> # deleting the product will cause expiration in any mode
-        >>> self.hasher = None
-        >>> product.delete()
+        >>> # corrupting the output will cause the stamp to expire
+        >>> product.write_text('very corrupted')
         >>> assert self.expired()
     """
     def __init__(self, fname, dpath, cfgstr=None, product=None, hasher='sha1',

--- a/ubelt/util_cache.py
+++ b/ubelt/util_cache.py
@@ -717,6 +717,12 @@ class CacheStamp(object):
     TODO:
         - [ ] expiration time delta or date time (also remember when renewed)
 
+        - [ ] optionally checking the hash of the product
+
+        - [ ] optionally checking a manually specified expected hash
+
+        - [ ] optionally checking the stamp time agrees with the product ctime
+
     Example:
         >>> import ubelt as ub
         >>> from os.path import join

--- a/ubelt/util_dict.pyi
+++ b/ubelt/util_dict.pyi
@@ -12,9 +12,9 @@ from collections.abc import Generator
 from typing import Any, TypeVar
 from ubelt import util_const
 
+T = TypeVar("T")
 KT = TypeVar("KT")
 VT = TypeVar("VT")
-T = TypeVar("T")
 odict = OrderedDict
 ddict = defaultdict
 

--- a/ubelt/util_dict.pyi
+++ b/ubelt/util_dict.pyi
@@ -12,9 +12,9 @@ from collections.abc import Generator
 from typing import Any, TypeVar
 from ubelt import util_const
 
+VT = TypeVar("VT")
 T = TypeVar("T")
 KT = TypeVar("KT")
-VT = TypeVar("VT")
 odict = OrderedDict
 ddict = defaultdict
 

--- a/ubelt/util_download.py
+++ b/ubelt/util_download.py
@@ -71,7 +71,8 @@ def download(url, fpath=None, dpath=None, fname=None, hash_prefix=None,
             operations like the connection attempt.
 
         progkw (Dict | None):
-            if specified provides extra arguments to the progress iterator
+            if specified provides extra arguments to the progress iterator.
+            See :class:`ubelt.progiter.ProgIter` for available options.
 
     Returns:
         str | PathLike: fpath - path to the downloaded file.
@@ -274,7 +275,7 @@ def grabdata(url, fpath=None, dpath=None, fname=None, redo=False,
     data.
 
     Args:
-        url (str): url to the file to download
+        url (str): url of the file to download
 
         fpath (Optional[str | PathLike]):
             The full path to download the file to. If unspecified, the
@@ -384,6 +385,8 @@ def grabdata(url, fpath=None, dpath=None, fname=None, redo=False,
         needs_download = True
 
     if hash_prefix:
+        # TODO: We should be able to use CacheStamp to abstract a lot of
+        # this logic away. But first CacheStamp needs to implement its TODOs
         stamp_fpath, needs_download = _check_hash_stamp(
             fpath, hash_prefix, hasher, verbose, needs_download)
 
@@ -404,6 +407,9 @@ def grabdata(url, fpath=None, dpath=None, fname=None, redo=False,
 
 
 def _check_hash_stamp(fpath, hash_prefix, hasher, verbose, needs_download=False):
+    """
+    Check for re-download conditions
+    """
     if isinstance(hasher, str):
         hasher_name = hasher
     else:

--- a/ubelt/util_list.pyi
+++ b/ubelt/util_list.pyi
@@ -8,9 +8,9 @@ from typing import List
 from collections.abc import Generator
 from typing import Any, TypeVar
 
+VT = TypeVar("VT")
 T = TypeVar("T")
 KT = TypeVar("KT")
-VT = TypeVar("VT")
 
 
 class chunks:

--- a/ubelt/util_list.pyi
+++ b/ubelt/util_list.pyi
@@ -8,9 +8,9 @@ from typing import List
 from collections.abc import Generator
 from typing import Any, TypeVar
 
+T = TypeVar("T")
 KT = TypeVar("KT")
 VT = TypeVar("VT")
-T = TypeVar("T")
 
 
 class chunks:

--- a/ubelt/util_path.py
+++ b/ubelt/util_path.py
@@ -681,7 +681,7 @@ class Path(_PathBase):
                 if True starts yield nodes closer to the root first otherwise
                 yield nodes closer to the leaves first.
 
-            onerror (callable):
+            onerror (Callable[[OSError], None]):
                 A function with one argument of type OSError. If the
                 error is raised the walk is aborted, otherwise it continues.
 
@@ -689,7 +689,7 @@ class Path(_PathBase):
                 if True recurse into symbolic directory links
 
         Yields:
-            Tuple[Path, str, str]: the root, file names, and directory names
+            Tuple['Path', str, str]: the root, file names, and directory names
 
         Example:
             >>> import ubelt as ub

--- a/ubelt/util_path.pyi
+++ b/ubelt/util_path.pyi
@@ -1,6 +1,7 @@
 from typing import Union
 from os import PathLike
 from typing import Tuple
+from collections.abc import Generator
 from typing import Any
 
 
@@ -96,4 +97,12 @@ class Path:
         ...
 
     def ls(self):
+        ...
+
+    def walk(
+        self,
+        topdown: bool = ...,
+        onerror: callable = ...,
+        followlinks: bool = ...
+    ) -> Generator[Tuple[Path, str, str], None, None]:
         ...

--- a/ubelt/util_path.pyi
+++ b/ubelt/util_path.pyi
@@ -1,6 +1,7 @@
 from typing import Union
 from os import PathLike
 from typing import Tuple
+from typing import Callable
 from collections.abc import Generator
 from typing import Any
 
@@ -102,7 +103,7 @@ class Path:
     def walk(
         self,
         topdown: bool = ...,
-        onerror: callable = ...,
+        onerror: Callable[[OSError], None] = ...,
         followlinks: bool = ...
-    ) -> Generator[Tuple[Path, str, str], None, None]:
+    ) -> Generator[Tuple['Path', str, str], None, None]:
         ...

--- a/ubelt/util_time.py
+++ b/ubelt/util_time.py
@@ -157,16 +157,16 @@ def timestamp(datetime=None, precision=0, method='iso8601'):
             utc_offset = str(tz_hour) if tz_hour < 0 else '+' + str(tz_hour)
         if precision > 0:
             fprecision = 6  # microseconds are padded to 6 decimals
-            if _needs_workaround39103():
+            if _needs_workaround39103():  # nocover
                 local_stamp = datetime.strftime('%04Y-%m-%dT%H%M%S.%f')
-            else:
+            else:  # nocover
                 local_stamp = datetime.strftime('%Y-%m-%dT%H%M%S.%f')
             ms_offset = len(local_stamp) - max(0, fprecision - precision)
             local_stamp = local_stamp[:ms_offset]
         else:
-            if _needs_workaround39103():
+            if _needs_workaround39103():  # nocover
                 local_stamp = datetime.strftime('%04Y-%m-%dT%H%M%S')
-            else:
+            else:  # nocover
                 local_stamp = datetime.strftime('%Y-%m-%dT%H%M%S')
         stamp = local_stamp + utc_offset
         return stamp

--- a/ubelt/util_time.py
+++ b/ubelt/util_time.py
@@ -151,7 +151,7 @@ def timeparse(stamp, allow_dateutil=True):
     `python-dateutil` package is installed.
 
     Args:
-        str (str):
+        stamp (str):
             a string encoded timestamp
 
         allow_dateutil (bool):

--- a/ubelt/util_time.py
+++ b/ubelt/util_time.py
@@ -106,9 +106,12 @@ def timestamp(datetime=None, precision=0, method='iso8601'):
         >>>     None,
         >>>     tzlocal()
         >>> ]
+        >>> # Note: there is a win32 bug here
+        >>> # https://bugs.python.org/issue37 that means we cant use
+        >>> # dates close to the epoch
         >>> datetime_list = [
-        >>>     datetime_cls.utcfromtimestamp(123456789.123456789),
-        >>>     datetime_cls.utcfromtimestamp(0),
+        >>>     datetime_cls.utcfromtimestamp(123456789.123456789 + 315360000),
+        >>>     datetime_cls.utcfromtimestamp(0 + 315360000),
         >>> ]
         >>> basis = {
         >>>     'precision': [0, 3, 9],

--- a/ubelt/util_time.py
+++ b/ubelt/util_time.py
@@ -128,7 +128,9 @@ def timestamp(datetime=None, precision=0, method='iso8601'):
         >>>     print(f'recon={recon}')
         >>>     print(f'alt  ={alt}')
         >>>     shift = 10 ** precision
-        >>>     assert int(dtime.timestamp() * shift) == int(recon.timestamp() * shift)
+        >>>     a = int(dtime.timestamp() * shift)
+        >>>     a = int(recon.timestamp() * shift)
+        >>>     assert a == b, f'{a} != {b}'
     """
     if method == 'iso8601':
         from datetime import datetime as datetime_cls

--- a/ubelt/util_time.py
+++ b/ubelt/util_time.py
@@ -120,7 +120,7 @@ def timestamp(datetime=None, precision=0, method='iso8601'):
         >>>     precision = params.get('precision', 0)
         >>>     stamp = ub.timestamp(datetime=dtime, precision=precision)
         >>>     recon = ub.timeparse(stamp)
-        >>>     alt = recon.strftime('%04Y-%m-%dT%H%M%S.%f%z')
+        >>>     alt = recon.strftime('%Y-%m-%dT%H%M%S.%f%z')
         >>>     print('---')
         >>>     print('params = {}'.format(ub.repr2(params, nl=1)))
         >>>     print(f'dtime={dtime}')

--- a/ubelt/util_time.py
+++ b/ubelt/util_time.py
@@ -3,16 +3,18 @@ This is util_time, it contains functions for handling time related code.
 
 The :func:`timestamp` function returns an iso8601 timestamp without much fuss.
 
+The :func:`timeparse` is the inverse of `timestamp`, and makes use of
+:mod:`dateutil` if it is available.
+
 The :class:`Timer` class is a context manager that times a block of indented
 code. It includes `tic` and `toc` methods a more matlab like feel.
 
-Timerit is gone! Use the standalone and separate module
-:class:`timerit.Timerit` But the :class:`.
+Timerit is gone! Use the standalone and separate module :module:`timerit`.
 """
 import time
 import sys
 
-__all__ = ['timestamp', 'Timer']
+__all__ = ['timestamp', 'timeparse', 'Timer']
 
 
 def timestamp(datetime=None, precision=0, method='iso8601'):
@@ -67,11 +69,11 @@ def timestamp(datetime=None, precision=0, method='iso8601'):
         >>> print('stamp = {!r}'.format(stamp))
         stamp = '1973-11-29T213309.12+0930'
 
-    Ignore:
+    Example:
         >>> # xdoctest: +REQUIRES(module:dateutil)
         >>> # Make sure we are compatible with dateutil
-        >>> import dateutil
-        >>> from dateutil import parser
+        >>> import ubelt as ub
+        >>> from dateutil.tz import tzlocal
         >>> import datetime as datetime_mod
         >>> from datetime import datetime as datetime_cls
         >>> tzinfo_list = [
@@ -80,24 +82,23 @@ def timestamp(datetime=None, precision=0, method='iso8601'):
         >>>     datetime_mod.timezone(datetime_mod.timedelta(hours=0), 'UTC'),
         >>>     datetime_mod.timezone.utc,
         >>>     None,
-        >>>     dateutil.tz.tzlocal()
+        >>>     tzlocal()
         >>> ]
         >>> datetime_list = [
         >>>     datetime_cls.utcfromtimestamp(123456789.123456789),
         >>>     datetime_cls.utcfromtimestamp(0),
         >>> ]
         >>> basis = {
-        >>>     #'precision': [0, 3, 9],
+        >>>     'precision': [0, 3, 9],
         >>>     'tzinfo': tzinfo_list,
         >>>     'datetime': datetime_list,
         >>> }
-        >>> import copy
         >>> for params in ub.named_product(basis):
         >>>     dtime = params['datetime'].replace(tzinfo=params['tzinfo'])
         >>>     precision = params.get('precision', 0)
         >>>     stamp = ub.timestamp(datetime=dtime, precision=precision)
-        >>>     recon = parser.parse(stamp)
-        >>>     alt = recon.strftime('%Y-%m-%dT%H%M%S.%f%z')
+        >>>     recon = ub.timeparse(stamp)
+        >>>     alt = recon.strftime('%04Y-%m-%dT%H%M%S.%f%z')
         >>>     print('---')
         >>>     print('params = {}'.format(ub.repr2(params, nl=1)))
         >>>     print(f'dtime={dtime}')
@@ -129,15 +130,163 @@ def timestamp(datetime=None, precision=0, method='iso8601'):
             utc_offset = str(tz_hour) if tz_hour < 0 else '+' + str(tz_hour)
         if precision > 0:
             fprecision = 6  # microseconds are padded to 6 decimals
-            local_stamp = datetime.strftime('%Y-%m-%dT%H%M%S.%f')
+            local_stamp = datetime.strftime('%04Y-%m-%dT%H%M%S.%f')
             ms_offset = len(local_stamp) - max(0, fprecision - precision)
             local_stamp = local_stamp[:ms_offset]
         else:
-            local_stamp = datetime.strftime('%Y-%m-%dT%H%M%S')
+            local_stamp = datetime.strftime('%04Y-%m-%dT%H%M%S')
         stamp = local_stamp + utc_offset
         return stamp
     else:
         raise ValueError('only iso8601 is allowed for method')
+
+
+def timeparse(stamp, allow_dateutil=True):
+    """
+    Create a :class:`datetime.datetime` object from a string timestamp.
+
+    Without any extra dependencies this will parse the output of
+    :func:`ubelt.util_time.timestamp()` into a datetime object. In the case
+    where the format differs, `dateutil.parser.parse` will be used if the
+    `python-dateutil` package is installed.
+
+    Args:
+        str (str):
+            a string encoded timestamp
+
+        allow_dateutil (bool):
+            if False we only use the minimal parsing and do not allow a
+            fallback to dateutil.
+
+    Returns:
+        datetime.datetime: the parsed datetime
+
+    Raises:
+        ValueError: if if parsing fails.
+
+    Example:
+        >>> import ubelt as ub
+        >>> # Demonstrate a round trip of timestamp and timeparse
+        >>> stamp = ub.timestamp()
+        >>> datetime = ub.timeparse(stamp)
+        >>> assert ub.timestamp(datetime) == stamp
+        >>> # Round trip with precision
+        >>> stamp = ub.timestamp(precision=4)
+        >>> datetime = ub.timeparse(stamp)
+        >>> assert ub.timestamp(datetime, precision=4) == stamp
+
+
+    Example:
+        >>> import ubelt as ub
+        >>> # We should always be able to parse these
+        >>> good_stamps = [
+        >>>     '2000-11-22T111111.44444Z',
+        >>>     '2000-11-22T111111.44444+5',
+        >>>     '2000-11-22T111111.44444-05',
+        >>>     '2000-11-22T111111.44444-0500',
+        >>>     '2000-11-22T111111.44444+0530',
+        >>>     '2000-11-22T111111Z',
+        >>>     '2000-11-22T111111+5',
+        >>>     '2000-11-22T111111+0530',
+        >>> ]
+        >>> for stamp in good_stamps:
+        >>>     print(f'----')
+        >>>     print(f'stamp={stamp}')
+        >>>     result = ub.timeparse(stamp, allow_dateutil=0)
+        >>>     print(f'result={result!r}')
+        >>>     recon = ub.timestamp(result)
+        >>>     print(f'recon={recon}')
+
+    Example:
+        >>> import ubelt as ub
+        >>> # We require dateutil to handle these types of stamps
+        >>> import pytest
+        >>> conditional_stamps = [
+        >>>         '2000-01-02T11:23:58.12345+5:30',
+        >>>         '09/25/2003',
+        >>>         'Thu Sep 25 10:36:28 2003',
+        >>> ]
+        >>> for stamp in conditional_stamps:
+        >>>     with pytest.raises(ValueError):
+        >>>         result = ub.timeparse(stamp, allow_dateutil=False)
+        >>> have_dateutil = bool(ub.modname_to_modpath('dateutil'))
+        >>> if have_dateutil:
+        >>>     for stamp in conditional_stamps:
+        >>>         result = ub.timeparse(stamp)
+
+    Ignore:
+        import timerit
+        ti = timerit.Timerit(1000, 10)
+        ti.reset('non-standard dateutil.parse').call(lambda: dateutil.parser.parse('2000-01-02T112358.12345+5'))
+        ti.reset('non-standard ubelt.timeparse').call(lambda: ub.timeparse('2000-01-02T112358.12345+5'))
+        ti.reset('standard dateutil.parse').call(lambda: dateutil.parser.parse('2000-01-02T112358.12345+0500'))
+        ti.reset('standard dateutil.isoparse').call(lambda: dateutil.parser.isoparse('2000-01-02T112358.12345+0500'))
+        ti.reset('standard ubelt.timeparse').call(lambda: ub.timeparse('2000-01-02T112358.12345+0500'))
+        ti.reset('standard datetime_cls.strptime').call(lambda: datetime_cls.strptime('2000-01-02T112358.12345+0500', '%Y-%m-%dT%H%M%S.%f%z'))
+    """
+    import datetime as datetime_mod
+    from datetime import datetime as datetime_cls
+    datetime = None
+    # Check if we might have a minimal format
+    maybe_minimal = (
+        len(stamp) >= 17 and 'T' in stamp[10:]
+    )
+    if maybe_minimal:
+        # Note by default %z only handles the format `[+-]HHMM(SS(.ffffff))`
+        # this means we have to handle the case where `[+-]HH` is given.
+        # We do this by checking the offset and padding it to at least the
+        # `[+-]HHMM` format
+        date_part, timetz_part = stamp.split('T', 1)
+        if '-' in timetz_part[6:]:
+            time_part, sign, tz_part = timetz_part.partition('-')
+        elif '+' in timetz_part[6:]:
+            time_part, sign, tz_part = timetz_part.partition('+')
+        else:
+            tz_part = None
+
+        if tz_part is not None:
+            if len(tz_part) == 1:
+                tz_part = '0{}00'.format(tz_part)
+            elif len(tz_part) == 2:
+                tz_part = '{}00'.format(tz_part)
+            stamp = ''.join([date_part, 'T', time_part, sign, tz_part])
+
+    if maybe_minimal:
+        minimal_formats = [
+            '%Y-%m-%dT%H%M%S%z',
+            '%Y-%m-%dT%H%M%S.%f%z',
+        ]
+        for fmt in minimal_formats:
+            try:
+                datetime = datetime_cls.strptime(stamp, fmt)
+            except ValueError:
+                pass
+            else:
+                break
+
+    if datetime is None:
+        # Our minimal logic did not work, can we use dateutil?
+        if not allow_dateutil:
+            raise ValueError((
+                'Cannot parse timestamp. '
+                'Unknown string format: {!r}, and '
+                'dateutil is not allowed').format(stamp))
+        else:
+            try:
+                from dateutil.parser import parse as du_parse
+            except ImportError:
+                raise ValueError((
+                    'Cannot parse timestamp. '
+                    'Unknown string format: {!r}, and '
+                    'dateutil is not installed').format(stamp))
+            else:
+                datetime = du_parse(stamp)
+
+    if datetime.tzinfo is None:
+        # If the timezone is unspecified assume the local timezone
+        tzinfo = datetime_mod.timezone(datetime_mod.timedelta(seconds=-time.timezone))
+        datetime = datetime.replace(tzinfo=tzinfo)
+    return datetime
 
 
 class Timer(object):

--- a/ubelt/util_time.py
+++ b/ubelt/util_time.py
@@ -160,9 +160,9 @@ def timestamp(datetime=None, precision=0, method='iso8601'):
             local_stamp = local_stamp[:ms_offset]
         else:
             if _needs_workaround39103():
-                local_stamp = datetime.strftime('%Y-%m-%dT%H%M%S')
-            else:
                 local_stamp = datetime.strftime('%04Y-%m-%dT%H%M%S')
+            else:
+                local_stamp = datetime.strftime('%Y-%m-%dT%H%M%S')
         stamp = local_stamp + utc_offset
         return stamp
     else:

--- a/ubelt/util_time.py
+++ b/ubelt/util_time.py
@@ -295,6 +295,8 @@ def timeparse(stamp, allow_dateutil=True):
         minimal_formats = [
             '%Y-%m-%dT%H%M%S%z',
             '%Y-%m-%dT%H%M%S.%f%z',
+            '%Y-%m-%dT%H%M%S',
+            '%Y-%m-%dT%H%M%S.%f',
         ]
         for fmt in minimal_formats:
             try:
@@ -318,8 +320,8 @@ def timeparse(stamp, allow_dateutil=True):
                 raise ValueError((
                     'Cannot parse timestamp. '
                     'Unknown string format: {!r}, and '
-                    'dateutil is not installed').format(stamp))
-            else:
+                    'dateutil is not installed').format(stamp)) from None
+            else:  # nocover
                 datetime = du_parse(stamp)
 
     if datetime.tzinfo is None:

--- a/ubelt/util_time.py
+++ b/ubelt/util_time.py
@@ -175,7 +175,6 @@ def timeparse(stamp, allow_dateutil=True):
         >>> datetime = ub.timeparse(stamp)
         >>> assert ub.timestamp(datetime, precision=4) == stamp
 
-
     Example:
         >>> import ubelt as ub
         >>> # We should always be able to parse these
@@ -223,11 +222,6 @@ def timeparse(stamp, allow_dateutil=True):
         ti.reset('standard dateutil.isoparse').call(lambda: dateutil.parser.isoparse('2000-01-02T112358.12345+0500'))
         ti.reset('standard ubelt.timeparse').call(lambda: ub.timeparse('2000-01-02T112358.12345+0500'))
         ti.reset('standard datetime_cls.strptime').call(lambda: datetime_cls.strptime('2000-01-02T112358.12345+0500', '%Y-%m-%dT%H%M%S.%f%z'))
-
-    Ignore:
-        datetime_cls.strptime('2000-11-22T111111', '%Y-%m-%dT%H%M%S')
-        datetime_cls.strptime('2000-11-22T111111+0000', '%Y-%m-%dT%H%M%S%z')
-        datetime_cls.strptime('2000-11-22T111111Z', '%Y-%m-%dT%H%M%S%z')
     """
     import datetime as datetime_mod
     from datetime import datetime as datetime_cls
@@ -287,7 +281,7 @@ def timeparse(stamp, allow_dateutil=True):
         else:
             try:
                 from dateutil.parser import parse as du_parse
-            except ImportError:  # nocover
+            except (ModuleNotFoundError, ImportError):  # nocover
                 raise ValueError((
                     'Cannot parse timestamp. '
                     'Unknown string format: {!r}, and '

--- a/ubelt/util_time.py
+++ b/ubelt/util_time.py
@@ -129,7 +129,7 @@ def timestamp(datetime=None, precision=0, method='iso8601'):
         >>>     print(f'alt  ={alt}')
         >>>     shift = 10 ** precision
         >>>     a = int(dtime.timestamp() * shift)
-        >>>     a = int(recon.timestamp() * shift)
+        >>>     b = int(recon.timestamp() * shift)
         >>>     assert a == b, f'{a} != {b}'
     """
     if method == 'iso8601':

--- a/ubelt/util_time.pyi
+++ b/ubelt/util_time.pyi
@@ -9,6 +9,10 @@ def timestamp(datetime: Union[datetime.datetime, None] = ...,
     ...
 
 
+def timeparse(stamp: str, allow_dateutil: bool = ...) -> datetime.datetime:
+    ...
+
+
 class Timer:
     label: Any
     verbose: Any


### PR DESCRIPTION
Adds `ub.timeparse` method to convert timestamps to datetime objects.

Adds the size, mtime, and expires checks to ub.CacheStamp.expired 