### PR TITLE
Refactor grabdata to use CacheStamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Deprecated
 * `product` and `cfgstr` arguments to `CacheStamp.expired`
 * `product` and `cfgstr` arguments to `CacheStamp.renew`
+* Passing `hasher` as an instance to functions like `grabdata` or `CacheStamp`
+  can cause unexpected hashes as they may be used more than once.
 
 ### Fixed
 * `ub.hash_data` now recognizes subclasses of registered types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * `ub.Path.walk` to wrap `os.walk`. 
 * `ub.CacheStamp` will now check the mtime and size to quickly check if the products
   have changed and force expiration.
-* `ub.CacheStamp` now takes an expires keyword arg, which will keep the cache valid 
+* `ub.CacheStamp` now takes an `expires` keyword arg, which will keep the cache valid 
   only for the specified amount of time.
+* `ub.CacheStamp` now takes an `hash_prefix` keyword arg, which will check that it
+  matches the hash of the product.
 
 ### Changed
 * Register `pathlib.Path` with `ub.repr2`
@@ -31,12 +33,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Can now register global `ub.hash_data` extensions `ub.hash_data..register`
 * Removed deprecated arguments from `ubelt.cmd`.
 
+### Deprecated
+* `product` and `cfgstr` arguments to `CacheStamp.expired`
+* `product` and `cfgstr` arguments to `CacheStamp.renew`
+
 ### Fixed
 * `ub.hash_data` now recognizes subclasses of registered types.
 * `ub.timestamp()` has been outputting incorrect (negated) UTC offsets. This is now fixed.
 * `ub.timestamp()` now works correctly when the year has less than 4 digits.
 
 ### Changed
+* The `ubelt.util_download.grabdata` function now uses `CacheStamp` instead of
+  implementing its own stamp solution.
 * The `ubelt.util_hash.HashableExtensions` implementation was updated to use
   `functools.singledispatch` instead of the custom solution. This seems faster
   and should not have any API impact.

--- a/README.rst
+++ b/README.rst
@@ -130,11 +130,10 @@ Ubelt is small. Its top-level API is defined using roughly 40 lines:
     from ubelt.util_str import (codeblock, ensure_unicode, hzcat, indent,
                                 paragraph,)
     from ubelt.util_stream import (CaptureStdout, CaptureStream, TeeStringIO,)
-    from ubelt.util_time import (Timer, timestamp,)
+    from ubelt.util_time import (Timer, timeparse, timestamp,)
     from ubelt.util_zip import (split_archive, zopen,)
     from ubelt.orderedset import (OrderedSet, oset,)
     from ubelt.progiter import (ProgIter,)
-
 
 Installation:
 =============
@@ -753,12 +752,9 @@ decided if its best to statically copy them into ubelt or require on pypi to
 satisfy the dependency. There are some tools that are not used by default 
 unless you explicitly allow for them. 
 
-Code that is currently statically included:
+Code that is currently statically included (vendored):
 
 -  ProgIter - https://github.com/Erotemic/progiter
-
-Code that is currently linked via pypi:
-
 -  OrderedSet - https://github.com/LuminosoInsight/ordered-set
 
 
@@ -767,6 +763,7 @@ Code that is completely optional, and only used in specific cases:
 - Numpy - ``ub.repr2`` will format a numpy array nicely by default
 - xxhash - this can be specified as a hasher to ``ub.hash_data``
 - Pygments - used by the ``util_color`` module.
+- dateutil - used by the ``util_time`` module.
 
 
 Similar Tools
@@ -778,23 +775,23 @@ listed here.
 Libraries that contain a broad scope of utilities:
 
 * Boltons: https://github.com/mahmoud/boltons
-
+* Toolz: https://github.com/pytoolz/toolz
+* CyToolz: https://github.com/pytoolz/cytoolz/
 
 Libraries that contain a specific scope of utilities:
 
-* More-Itertools: https://pypi.org/project/more-itertools/
-* Toolz: https://github.com/pytoolz/toolz
-* CyToolz: https://github.com/pytoolz/cytoolz/
-* Funcy: https://github.com/Suor/funcy
-* Rich: https://github.com/willmcgugan/rich
+* More-Itertools: iteration tools: https://pypi.org/project/more-itertools/
+* Funcy: functional tools: https://github.com/Suor/funcy
+* Rich: pretty CLI displays - https://github.com/willmcgugan/rich
+* tempora: time related tools - https://github.com/jaraco/tempora
 
 
 Libraries that contain one specific data structure or utility:
 
-* Benedict: https://pypi.org/project/python-benedict/
-* tqdm: https://pypi.org/project/tqdm/
-* pooch: https://pypi.org/project/pooch/
-* timerit - https://github.com/Erotemic/timerit
+* Benedict: dictionary tools - https://pypi.org/project/python-benedict/
+* tqdm: progress bars - https://pypi.org/project/tqdm/
+* pooch: data downloading - https://pypi.org/project/pooch/
+* timerit: snippet timing for benchmarks - https://github.com/Erotemic/timerit
 
 
 Notes.

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -145,6 +145,22 @@ def test_grabdata_cache():
 
 
 @pytest.mark.timeout(TIMEOUT)
+def test_grabdata_nohash():
+    """
+    Check where the url is downloaded to when fpath is not specified.
+    """
+    url = _demo_url()
+    dpath = ub.Path.appdir('ubelt/tests/test-grabdata-nohash').ensuredir()
+    fname = basename(url)
+    fpath = (dpath / fname).delete()
+    assert not fpath.exists()
+    ub.grabdata(url, fpath=fpath, hasher=None, verbose=10)
+    assert fpath.exists()
+    # Even without the hasher, if the size of the data changes at all
+    # we should be able to detect and correct it.
+
+
+@pytest.mark.timeout(TIMEOUT)
 def test_grabdata_url_only():
     """
     Check where the url is downloaded to when fpath is not specified.

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -307,7 +307,6 @@ def test_grabdata_hash_typo():
 
     """
     # url = 'https://www.dropbox.com/s/jl506apezj42zjz/ibeis-win32-setup-ymd_hm-2015-08-01_16-28.exe?dl=1'
-    import hashlib
     # url = 'http://i.imgur.com/rqwaDag.png'
     # if not ub.argflag('--network'):
     #     pytest.skip('not running network tests')
@@ -328,14 +327,14 @@ def test_grabdata_hash_typo():
         with pytest.raises(RuntimeError):
             got_fpath = ub.grabdata(
                 url, hash_prefix='e09c80c42fda5-typo-5f9d992e59ca6b3307d',
-                hasher=hashlib.md5(), verbose=verbose)
+                hasher='md5', verbose=verbose)
         assert fpath.exists()
         real_hash = ub.hash_file(fpath, hasher='md5')
 
         print('[STEP2] Fixing the typo recomputes the hash, but does not redownload the file')
         got_fpath = ub.grabdata(url,
                                 hash_prefix='e09c80c42fda55f9d992e59ca6b3307d',
-                                hasher=hashlib.md5(), verbose=verbose)
+                                hasher='md5', verbose=verbose)
         assert got_fpath == str(fpath)
         assert fpath.exists()
 
@@ -344,8 +343,20 @@ def test_grabdata_hash_typo():
         print('[STEP3] Deleting the hash file recomputes the hash')
         got_fpath = ub.grabdata(url, fpath=fpath,
                                 hash_prefix='e09c80c42fda55f9d992e59ca6b3307d',
-                                hasher=hashlib.md5(), verbose=verbose)
+                                hasher='md5', verbose=verbose)
         assert stamp_fpath.exists()
+
+
+def test_deprecated_grabdata_args():
+    with pytest.warns(DeprecationWarning):
+        import hashlib
+        url = _demo_url()
+        dpath = ub.ensure_app_cache_dir('ubelt')
+        fname = basename(url)
+        fpath = join(dpath, fname)
+        got_fpath = ub.grabdata(
+            url, hash_prefix='e09c80c42fda55f9d992e59ca6b3307d',
+            hasher=hashlib.md5())
 
 
 class SingletonTestServer(ub.NiceRepr):

--- a/ubelt/util_cache.py
+++ b/ubelt/util_cache.py
@@ -951,7 +951,10 @@ class CacheStamp(object):
         certificate = self._get_certificate(cfgstr=cfgstr)
         if certificate is None:
             # We don't have a certificate, so we are expired
-            return 'no_cert'
+            err = 'no_cert'
+            if self.cacher.verbose > 0:  # pragma: nobranch
+                print('[cacher] stamp expired {}'.format(err))
+            return err
 
         expires = certificate['expires']
         if expires is not None:
@@ -961,7 +964,10 @@ class CacheStamp(object):
             expires_abs = util_time.timeparse(expires)
             if  now >= expires_abs:
                 # We are expired
-                return 'expired_cert'
+                err = 'expired_cert'
+                if self.cacher.verbose > 0:  # pragma: nobranch
+                    print('[cacher] stamp expired {}'.format(err))
+                return err
 
         products = self._rectify_products(product)
         if products is None:
@@ -969,7 +975,10 @@ class CacheStamp(object):
             return False
         elif not all(map(exists, products)):
             # We are expired if the expected product does not exist
-            return 'missing_products'
+            err = 'missing_products'
+            if self.cacher.verbose > 0:  # pragma: nobranch
+                print('[cacher] stamp expired {}'.format(err))
+            return err
         else:
             # First test to see if the size or mtime of the files has changed
             # as a potentially quicker check. If sizes or mtimes do not exist
@@ -979,12 +988,18 @@ class CacheStamp(object):
             if sizes is not None and self.expire_checks['size']:
                 if sizes != product_file_stats['size']:
                     # The sizes are differnt, we are expired
-                    return  'size_diff'
+                    err =  'size_diff'
+                    if self.cacher.verbose > 0:  # pragma: nobranch
+                        print('[cacher] stamp expired {}'.format(err))
+                    return err
             mtimes = certificate.get('mtime', None)
             if mtimes is not None and self.expire_checks['mtime']:
                 if mtimes != product_file_stats['mtime']:
                     # The sizes are differnt, we are expired
-                    return 'mtime_diff'
+                    err = 'mtime_diff'
+                    if self.cacher.verbose > 0:  # pragma: nobranch
+                        print('[cacher] stamp expired {}'.format(err))
+                    return err
 
             err = self._check_certificate_hashes(certificate)
             if err:
@@ -999,7 +1014,10 @@ class CacheStamp(object):
                     print('invalid hash value (expected "{}", got "{}")'.format(
                         product_file_hash, certificate_hash))
                 # The hash is different, we are expired
-                return 'hash_diff'
+                err = 'hash_diff'
+                if self.cacher.verbose > 0:
+                    print('[cacher] stamp expired {}'.format(err))
+                return err
 
         # All tests passed, we are not expired
         return False
@@ -1013,7 +1031,8 @@ class CacheStamp(object):
                     if self.cacher.verbose > 0:
                         print('invalid hash prefix value (expected "{}", got "{}")'.format(
                             pref_hash, cert_hash))
-                    return 'hash_prefix_mismatch'
+                    err = 'hash_prefix_mismatch'
+                    return err
 
     def _expires(self, now=None):
         """

--- a/ubelt/util_cache.py
+++ b/ubelt/util_cache.py
@@ -190,6 +190,8 @@ class Cacher(object):
                  ext='.pkl', meta=None, verbose=None, enabled=True, log=None,
                  hasher='sha1', protocol=-1, cfgstr=None, backend='auto'):
 
+        # TODO: maybe allow depends to be None, and just warn if it defaults to
+        # NoParam?
         if depends is None:
             depends = cfgstr
 
@@ -265,7 +267,7 @@ class Cacher(object):
 
         if cfgstr is None and self.enabled:
             warnings.warn(
-                'No cfgstr given in Cacher constructor or call for {}'.format(
+                'No depends given in Cacher constructor or call for {}'.format(
                     self.fname), UserWarning)
             cfgstr = ''
         if self.fname is None:
@@ -813,7 +815,15 @@ class CacheStamp(object):
         if self.hasher is None:
             hasher_name = None
         else:
-            hasher_name = self.hasher if isinstance(self.hasher, str) else self.hasher.name
+            if not isinstance(self.hasher, str):  # nocover
+                from ubelt import _util_deprecated
+                _util_deprecated.schedule_deprecation2(
+                    migration='Pass hasher as a string',
+                    name='hasher', type='CacheStamp arg',
+                    deprecate='1.1.0', error='1.3.0', remove='1.4.0')
+                hasher_name = self.hasher.name
+            else:
+                hasher_name = self.hasher
         product_info['hasher'] = hasher_name
         product_info['hash'] = self._product_file_hash(products)
         return product_info
@@ -920,14 +930,14 @@ class CacheStamp(object):
             >>> with pytest.raises(RuntimeError):
             ...     self.renew()
         """
-        if cfgstr is not None:
+        if cfgstr is not None:  # nocover
             from ubelt import _util_deprecated
             _util_deprecated.schedule_deprecation2(
                 migration='Do not pass cfgstr to expired. Use the class depends arg',
                 name='cfgstr', type='CacheStamp.expires arg',
                 deprecate='1.1.0', error='1.3.0', remove='1.4.0',
             )
-        if product is not None:
+        if product is not None:  # nocover
             from ubelt import _util_deprecated
             _util_deprecated.schedule_deprecation2(
                 migration='Do not pass product to expired. Use the class product arg',
@@ -1097,14 +1107,14 @@ class CacheStamp(object):
         Returns:
             dict: certificate information
         """
-        if cfgstr is not None:
+        if cfgstr is not None:  # nocover
             from ubelt import _util_deprecated
             _util_deprecated.schedule_deprecation2(
                 migration='Do not pass cfgstr to renew. Use the class depends arg',
                 name='cfgstr', type='CacheStamp.renew arg',
                 deprecate='1.1.0', error='1.3.0', remove='1.4.0',
             )
-        if product is not None:
+        if product is not None:  # nocover
             from ubelt import _util_deprecated
             _util_deprecated.schedule_deprecation2(
                 migration='Do not pass product to renew. Use the class product arg',

--- a/ubelt/util_cache.pyi
+++ b/ubelt/util_cache.pyi
@@ -72,6 +72,9 @@ class CacheStamp:
     cacher: Any
     product: Any
     hasher: Any
+    expires: Any
+    hash_prefix: Any
+    expire_checks: Any
 
     def __init__(self,
                  fname,
@@ -82,7 +85,10 @@ class CacheStamp:
                  verbose: Any | None = ...,
                  enabled: bool = ...,
                  depends: Any | None = ...,
-                 meta: Any | None = ...) -> None:
+                 meta: Any | None = ...,
+                 hash_prefix: Any | None = ...,
+                 expires: Any | None = ...,
+                 ext: str = ...) -> None:
         ...
 
     def expired(
@@ -90,7 +96,7 @@ class CacheStamp:
         cfgstr: Union[str, None] = ...,
         product: Union[str, PathLike, Sequence[Union[str, PathLike]],
                        None] = ...
-    ) -> bool:
+    ) -> bool | str:
         ...
 
     def renew(self,

--- a/ubelt/util_dict.pyi
+++ b/ubelt/util_dict.pyi
@@ -12,9 +12,9 @@ from collections.abc import Generator
 from typing import Any, TypeVar
 from ubelt import util_const
 
-VT = TypeVar("VT")
 T = TypeVar("T")
 KT = TypeVar("KT")
+VT = TypeVar("VT")
 odict = OrderedDict
 ddict = defaultdict
 

--- a/ubelt/util_download.py
+++ b/ubelt/util_download.py
@@ -304,6 +304,8 @@ def grabdata(url, fpath=None, dpath=None, fname=None, redo=False,
         hasher (str | Hasher):
             If hash_prefix is specified, this indicates the hashing
             algorithm to apply to the file. Defaults to sha512.
+            NOTE: Only pass hasher as a string. Passing as an instance is
+            deprecated and can cause unexpected results.
 
         **download_kw: additional kwargs to pass to
             :func:`ubelt.util_download.download`
@@ -387,7 +389,16 @@ def grabdata(url, fpath=None, dpath=None, fname=None, redo=False,
 
     if 1:
         if hasher is not None:
-            depends = hasher if isinstance(hasher, str) else hasher.name
+            if not isinstance(hasher, str):
+                from ubelt import _util_deprecated
+                _util_deprecated.schedule_deprecation2(
+                    migration='Pass hasher as a string, otherwise unexpected behavior can occur',
+                    name='hasher', type='grabdata arg',
+                    deprecate='1.1.0', error='1.3.0', remove='1.4.0')
+                hasher_name = hasher.name
+            else:
+                hasher_name = hasher
+            depends = hasher_name
         else:
             depends = ''
         # TODO: it would be nice to have better control over the name of the

--- a/ubelt/util_list.pyi
+++ b/ubelt/util_list.pyi
@@ -8,9 +8,9 @@ from typing import List
 from collections.abc import Generator
 from typing import Any, TypeVar
 
-VT = TypeVar("VT")
 T = TypeVar("T")
 KT = TypeVar("KT")
+VT = TypeVar("VT")
 
 
 class chunks:


### PR DESCRIPTION
Refactors ub.grab_data to use ub.CacheStamp instead of its own caching solution.

This also adds support to ub.CacheStamp for hash_prefix, which will expire if it is incorrect and also prevent renewal.