### PR TITLE
Fix CacheStamp issue with old caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 * Issue #113, where a `ub.find_exe` test failed on Gentoo. Fixed by #114
+* Issue where older versions of CacheStamp would be interpreted as 1.1 stamps.
 
 ## Version 1.1.0 - Released 2022-06-03
 

--- a/ubelt/util_cache.py
+++ b/ubelt/util_cache.py
@@ -1007,7 +1007,7 @@ class CacheStamp(object):
                 print('[cacher] stamp expired {}'.format(err))
             return err
 
-        expires = certificate['expires']
+        expires = certificate.get('expires', None)
         if expires is not None:
             from ubelt import util_time
             # Need to add in the local timezone to compare against the cert.


### PR DESCRIPTION
To reproduce: 

```bash
docker run -it python3 bash

pip install ubelt==1.0.0
python -c "import ubelt; ubelt.CacheStamp('foo', '.').renew()"
pip install ubelt==1.1.0
python -c "import ubelt; ubelt.CacheStamp('foo', '.').expired()"
```