### PR TITLE
Remove incorrect wheel requirement from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = [ "setuptools>=41.0.1", "wheel>=0.37.1",]
+requires = [ "setuptools>=41.0.1",]
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
Remove the incorrect `wheel` dependency, as it is added by the backend
automatically.  Listing it explicitly in the documentation was
a historical mistake and has been fixed since, see:
https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a