### PR TITLE
Deprecate download manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ This project (loosely) adheres to [Semantic Versioning](https://semver.org/spec/
   default.
 * All .pyi files have been removed. Type annotations are now inline and validated with mypy and ty.
 
+### Deprecated
+* Deprecated `DownloadManager`, due to being over scoped.
+
 
 ## Version 1.4.0 - Released 2025-08-16
 

--- a/ubelt/util_download_manager.py
+++ b/ubelt/util_download_manager.py
@@ -90,6 +90,20 @@ class DownloadManager:
                   "connection state" objects.
         """
         import ubelt as ub
+        # The download manager is overscoped and doesn't provide enough value
+        # over the simple download function. This is better suited for a
+        # separate package rather than a utility library. A proper download
+        # manager would be multiplexing connections and have many more
+        # efficiency tricks that would bloat a ubelt implementation.
+        ub.schedule_deprecation(
+            modname='ubelt',
+            name='DownloadManager',
+            type='class',
+            migration='Vendor the code if you need it.',
+            deprecate='1.4.1',
+            error='2.0.0',
+            remove='2.1.0',
+        )
         if download_root is None:
             download_root = ub.ensure_app_config_dir('ubelt', 'dlman')
         self._pool = ub.JobPool(mode=mode, max_workers=max_workers)


### PR DESCRIPTION
The download manager is overscoped and doesn't provide enough value over the simple download function. This is better suited for a separate package rather than a utility library. A proper download manager would be multiplexing connections and have many more efficiency tricks that would bloat a ubelt implementation.

Thus we are slating it for deprecation and removal. I don't think anyone is using it, but if they are I might port it to xdev. It just doesn't make sense in ubelt. 